### PR TITLE
Rename package to @sinonjs/fake-clock

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,1 @@
-lolex.js
+fake-timers.js

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-Are you wondering how to do something with Lolex, or something else that is purely
+Are you wondering how to do something with FakeTimers, or something else that is purely
 usage related? Please post it to StackOverflow using the `sinon` and `lolex` labels.
 This makes it possible for the bigger community to help answer your questions.
 
@@ -9,7 +9,7 @@ The issue tracker is solely meant for posting bugs, feature requests and non-usa
 > We understand you have a problem and are in a hurry, but please provide us with some info to make it much more likely for your issue to be understood, worked on and resolved quickly.
 
 
-* Lolex version : _please verify that the bug exists in the latest Lolex release_
+* FakeTimers version : _please verify that the bug exists in the latest FakeTimers release_
 * Environment   : <!-- Browser, OS, ... -->
 * Example URL   : <!-- If you have one, such as a jsbin -->
 * Other libraries you are using:

--- a/README.md
+++ b/README.md
@@ -1,38 +1,38 @@
-# Lolex [![CircleCI](https://circleci.com/gh/sinonjs/lolex.svg?style=svg)](https://circleci.com/gh/sinonjs/lolex) [![codecov](https://codecov.io/gh/sinonjs/lolex/branch/master/graph/badge.svg)](https://codecov.io/gh/sinonjs/lolex)
+# `@sinonjs/fake-timers` [![CircleCI](https://circleci.com/gh/sinonjs/fake-timers.svg?style=svg)](https://circleci.com/gh/sinonjs/fake-timers) [![codecov](https://codecov.io/gh/sinonjs/fake-timers/branch/master/graph/badge.svg)](https://codecov.io/gh/sinonjs/fake-timers)
 
-JavaScript implementation of the timer APIs; `setTimeout`, `clearTimeout`, `setImmediate`, `clearImmediate`, `setInterval`, `clearInterval`, `requestAnimationFrame`, `cancelAnimationFrame`, `requestIdleCallback`, and `cancelIdleCallback`, along with a clock instance that controls the flow of time. Lolex also provides a `Date` implementation that gets its time from the clock.
+JavaScript implementation of the timer APIs; `setTimeout`, `clearTimeout`, `setImmediate`, `clearImmediate`, `setInterval`, `clearInterval`, `requestAnimationFrame`, `cancelAnimationFrame`, `requestIdleCallback`, and `cancelIdleCallback`, along with a clock instance that controls the flow of time. FakeTimers also provides a `Date` implementation that gets its time from the clock.
 
-In addition in browser environment lolex provides a `performance` implementation that gets its time from the clock. In Node environments lolex provides a `nextTick` implementation that is synchronized with the clock - and a `process.hrtime` shim that works with the clock.
+In addition in browser environment `@sinonjs/fake-timers` provides a `performance` implementation that gets its time from the clock. In Node environments FakeTimers provides a `nextTick` implementation that is synchronized with the clock - and a `process.hrtime` shim that works with the clock.
 
-Lolex can be used to simulate passing time in automated tests and other
+`@sinonjs/fake-timers` can be used to simulate passing time in automated tests and other
 situations where you want the scheduling semantics, but don't want to actually
-wait (however, from version 2.0 lolex supports those of you who would like to wait too).
+wait.
 
-Lolex is extracted from [Sinon.JS](https://github.com/sinonjs/sinon.js) and targets the [same runtimes](https://sinonjs.org/releases/latest/#supported-runtimes).
+`@sinonjs/fake-timers` is extracted from [Sinon.JS](https://github.com/sinonjs/sinon.js) and targets the [same runtimes](https://sinonjs.org/releases/latest/#supported-runtimes).
 
 ## Installation
 
-Lolex can be used in both Node and browser environments. Installation is as easy as
+`@sinonjs/fake-timers` can be used in both Node and browser environments. Installation is as easy as
 
 ```sh
-npm install lolex
+npm install @sinonjs/fake-timers
 ```
 
-If you want to use Lolex in a browser you can use [the pre-built
-version](https://github.com/sinonjs/lolex/blob/master/lolex.js) available in the repo
-and the npm package. Using npm you only need to reference `./node_modules/lolex/lolex.js` in your `<script>` tags.
+If you want to use `@sinonjs/fake-timers` in a browser you can use [the pre-built
+version](https://github.com/sinonjs/fake-timers/blob/master/fake-timers.js) available in the repo
+and the npm package. Using npm you only need to reference `./node_modules/@sinonjs/fake-timers.js` in your `<script>` tags.
 
-You are always free to [build it yourself](https://github.com/sinonjs/lolex/blob/53ea4d9b9e5bcff53cc7c9755dc9aa340368cf1c/package.json#L22), of course.
+You are always free to [build it yourself](https://github.com/sinonjs/@sinonjs/fake-timers/blob/53ea4d9b9e5bcff53cc7c9755dc9aa340368cf1c/package.json#L22), of course.
 
 ## Usage
 
-To use lolex, create a new clock, schedule events on it using the timer
+To use `@sinonjs/fake-timers`, create a new clock, schedule events on it using the timer
 functions and pass time using the `tick` method.
 
 ```js
-// In the browser distribution, a global `lolex` is already available
-var lolex = require("lolex");
-var clock = lolex.createClock();
+// In the browser distribution, a global `FakeTimers` is already available
+var FakeTimers = require("@sinonjs/fake-timers");
+var clock = FakeTimers.createClock();
 
 clock.setTimeout(function () {
     console.log("The poblano is a mild chili pepper originating in the state of Puebla, Mexico.");
@@ -53,7 +53,7 @@ API Reference for more details.
 
 ### Faking the native timers
 
-When using lolex to test timers, you will most likely want to replace the native
+When using `@sinonjs/fake-timers` to test timers, you will most likely want to replace the native
 timers such that calling `setTimeout` actually schedules a callback with your
 clock instance, not the browser's internals.
 
@@ -61,12 +61,12 @@ Calling `install` with no arguments achieves this. You can call `uninstall`
 later to restore things as they were again.
 
 ```js
-// In the browser distribution, a global `lolex` is already available
-var lolex = require("lolex");
+// In the browser distribution, a global `FakeTimers` is already available
+var FakeTimers = require("@sinonjs/fake-timers");
 
-var clock = lolex.install();
+var clock = FakeTimers.install();
 // Equivalent to
-// var clock = lolex.install(typeof global !== "undefined" ? global : window);
+// var clock = FakeTimers.install(typeof global !== "undefined" ? global : window);
 
 setTimeout(fn, 15); // Schedules with clock.setTimeout
 
@@ -77,11 +77,11 @@ clock.uninstall();
 To hijack timers in another context pass it to the `install` method.
 
 ```js
-var lolex = require("lolex");
+var FakeTimers = require("@sinonjs/fake-timers");
 var context = {
     setTimeout: setTimeout // By default context.setTimeout uses the global setTimeout
 }
-var clock = lolex.install({target: context});
+var clock = FakeTimers.install({target: context});
 
 context.setTimeout(fn, 15); // Schedules with clock.setTimeout
 
@@ -93,7 +93,7 @@ Usually you want to install the timers onto the global object, so call `install`
 without arguments.
 
 #### Automatically incrementing mocked time
-Since version 2.0 Lolex supports the possibility to attach the faked timers
+Since version 2.0 FakeTimers supports the possibility to attach the faked timers
 to any change in the real system time. This basically means you no longer need
 to `tick()` the clock in a situation where you won't know **when** to call `tick()`.
 
@@ -104,8 +104,8 @@ be incremented every 20ms, not in real time.
 An example would be:
 
 ```js
-var lolex = require("lolex");
-var clock = lolex.install({shouldAdvanceTime: true, advanceTimeDelta: 40});
+var FakeTimers = require("@sinonjs/fake-timers");
+var clock = FakeTimers.install({shouldAdvanceTime: true, advanceTimeDelta: 40});
 
 setTimeout(() => {
     console.log('this just timed out'); //executed after 40ms
@@ -123,7 +123,7 @@ setTimeout(() => {
 
 ## API Reference
 
-### `var clock = lolex.createClock([now[, loopLimit]])`
+### `var clock = FakeTimers.createClock([now[, loopLimit]])`
 
 Creates a clock. The default
 [epoch](https://en.wikipedia.org/wiki/Epoch_%28reference_date%29) is `0`.
@@ -132,23 +132,23 @@ The `now` argument may be a number (in milliseconds) or a Date object.
 
 The `loopLimit` argument sets the maximum number of timers that will be run when calling `runAll()` before assuming that we have an infinite loop and throwing an error. The default is `1000`.
 
-### `var clock = lolex.install([config])`
-Installs lolex using the specified config (otherwise with epoch `0` on the global scope). The following configuration options are available
+### `var clock = FakeTimers.install([config])`
+Installs FakeTimers using the specified config (otherwise with epoch `0` on the global scope). The following configuration options are available
 
 Parameter | Type | Default | Description
 --------- | ---- | ------- | ------------
-`config.target`| Object | global | installs lolex onto the specified target context
-`config.now` | Number/Date | 0 | installs lolex with the specified unix epoch
-`config.toFake` | String[] | ["setTimeout", "clearTimeout", "setImmediate", "clearImmediate","setInterval", "clearInterval", "Date", "requestAnimationFrame", "cancelAnimationFrame", "requestIdleCallback", "cancelIdleCallback", "hrtime"] | an array with explicit function names to hijack. *When not set, lolex will automatically fake all methods **except** `nextTick`* e.g., `lolex.install({ toFake: ["setTimeout","nextTick"]})` will fake only `setTimeout` and `nextTick`
+`config.target`| Object | global | installs FakeTimers onto the specified target context
+`config.now` | Number/Date | 0 | installs FakeTimers with the specified unix epoch
+`config.toFake` | String[] | ["setTimeout", "clearTimeout", "setImmediate", "clearImmediate","setInterval", "clearInterval", "Date", "requestAnimationFrame", "cancelAnimationFrame", "requestIdleCallback", "cancelIdleCallback", "hrtime"] | an array with explicit function names to hijack. *When not set, FakeTimers will automatically fake all methods **except** `nextTick`* e.g., `FakeTimers.install({ toFake: ["setTimeout","nextTick"]})` will fake only `setTimeout` and `nextTick`
 `config.loopLimit` | Number | 1000 | the maximum number of timers that will be run when calling runAll()
-`config.shouldAdvanceTime` | Boolean | false | tells lolex to increment mocked time automatically based on the real system time shift (e.g. the mocked time will be incremented by 20ms for every 20ms change in the real system time)
+`config.shouldAdvanceTime` | Boolean | false | tells FakeTimers to increment mocked time automatically based on the real system time shift (e.g. the mocked time will be incremented by 20ms for every 20ms change in the real system time)
 `config.advanceTimeDelta` | Number | 20 | relevant only when using with `shouldAdvanceTime: true`. increment mocked time by `advanceTimeDelta` ms every `advanceTimeDelta` ms change in the real system time.
 
 ### `var id = clock.setTimeout(callback, timeout)`
 
 Schedules the callback to be fired once `timeout` milliseconds have ticked by.
 
-In Node.js `setTimeout` returns a timer object. Lolex will do the same, however
+In Node.js `setTimeout` returns a timer object. FakeTimers will do the same, however
 its `ref()` and `unref()` methods have no effect.
 
 In browsers a timer ID is returned.
@@ -163,7 +163,7 @@ Clears the timer given the ID or timer object, as long as it was created using
 Schedules the callback to be fired every time `timeout` milliseconds have ticked
 by.
 
-In Node.js `setInterval` returns a timer object. Lolex will do the same, however
+In Node.js `setInterval` returns a timer object. FakeTimers will do the same, however
 its `ref()` and `unref()` methods have no effect.
 
 In browsers a timer ID is returned.
@@ -180,7 +180,7 @@ that you'll still have to call `clock.tick()` for the callback to fire. If
 called during a tick the callback won't fire until `1` millisecond has ticked
 by.
 
-In Node.js `setImmediate` returns a timer object. Lolex will do the same,
+In Node.js `setImmediate` returns a timer object. FakeTimers will do the same,
 however its `ref()` and `unref()` methods have no effect.
 
 In browsers a timer ID is returned.
@@ -244,7 +244,7 @@ callbacks to execute _before_ running the timers.
 ### `clock.reset()`
 
 Removes all timers and ticks without firing them, and sets `now` to `config.now`
-that was provided to `lolex.install` or to `0` if `config.now` was not provided.
+that was provided to `FakeTimers.install` or to `0` if `config.now` was not provided.
 Useful to reset the state of the clock without having to `uninstall` and `install` it.
 
 ### `clock.runAll()` / `await clock.runAllAsync()`
@@ -260,7 +260,7 @@ callbacks to execute _before_ running the timers.
 
 ### `clock.runMicrotasks()`
 
-This runs all pending microtasks scheduled with `nextTick` but none of the timers and is mostly useful for libraries using lolex underneath and for running `nextTick` items without any timers.
+This runs all pending microtasks scheduled with `nextTick` but none of the timers and is mostly useful for libraries using FakeTimers underneath and for running `nextTick` items without any timers.
 
 ### `clock.runToFrame()`
 
@@ -291,7 +291,7 @@ setSystemTime().
 ### `clock.uninstall()`
 
 Restores the original methods on the `target` that was passed to
-`lolex.install`, or the native timers if no `target` was given.
+`FakeTimers.install`, or the native timers if no `target` was given.
 
 ### `Date`
 
@@ -301,13 +301,13 @@ Implements the `Date` object but using the clock to provide the correct time.
 
 Implements the `now` method of the [`Performance`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now) object but using the clock to provide the correct time. Only available in environments that support the Performance object (browsers mostly).
 
-### `lolex.withGlobal`
+### `FakeTimers.withGlobal`
 
-In order to support creating clocks based on separate or sandboxed environments (such as JSDOM), Lolex exports a factory method which takes single argument `global`, which it inspects to figure out what to mock and what features to support. When invoking this function with a global, you will get back an object with `timers`, `createClock` and `install` - same as the regular Lolex exports only based on the passed in global instead of the global environment.
+In order to support creating clocks based on separate or sandboxed environments (such as JSDOM), FakeTimers exports a factory method which takes single argument `global`, which it inspects to figure out what to mock and what features to support. When invoking this function with a global, you will get back an object with `timers`, `createClock` and `install` - same as the regular FakeTimers exports only based on the passed in global instead of the global environment.
 
 ## Running tests
 
-Lolex has a comprehensive test suite. If you're thinking of contributing bug
+FakeTimers has a comprehensive test suite. If you're thinking of contributing bug
 fixes or suggesting new features, you need to make sure you have not broken any
 tests. You are also expected to add tests for any new behavior.
 
@@ -320,7 +320,7 @@ npm test
 Or, if you prefer more verbose output:
 
 ```
-$(npm bin)/mocha ./test/lolex-test.js
+$(npm bin)/mocha ./test/fake-timers-test.js
 ```
 
 ### In the browser

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-# Rolling Lolex releases
+# Rolling `@sinonjs/fake-timers` releases
 
 You'll need a working installation of [git-extras](https://github.com/tj/git-extras) for this.
 
@@ -20,5 +20,5 @@ $ npm publish
 
 Create a GitHub release where you highlight
 interesting additions from the changelog.
-Just add a release notes to [the existing tag](https://github.com/sinonjs/lolex/tags).
+Just add a release notes to [the existing tag](https://github.com/sinonjs/fake-timers/tags).
 

--- a/fake-timers.js
+++ b/fake-timers.js
@@ -1,4 +1,4 @@
-(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.lolex = f()}})(function(){var define,module,exports;return (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.FakeTimers = f()}})(function(){var define,module,exports;return (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
 "use strict";
 
 var every = require("./prototypes/array").every;
@@ -1856,7 +1856,7 @@ function withGlobal(_global) {
                 });
             }
 
-            clock.performance.now = function lolexNow() {
+            clock.performance.now = function FakeTimersNow() {
                 var hrt = hrtime();
                 var millis = hrt[0] * 1000 + hrt[1] / 1e6;
                 return millis;
@@ -1876,24 +1876,11 @@ function withGlobal(_global) {
      * @param config.now {number|Date}  a number (in milliseconds) or a Date object (default epoch)
      * @param config.toFake {string[]} names of the methods that should be faked.
      * @param config.loopLimit {number} the maximum number of timers that will be run when calling runAll()
-     * @param config.shouldAdvanceTime {Boolean} tells lolex to increment mocked time automatically (default false)
+     * @param config.shouldAdvanceTime {Boolean} tells FakeTimers to increment mocked time automatically (default false)
      * @param config.advanceTimeDelta {Number} increment mocked time every <<advanceTimeDelta>> ms (default: 20ms)
      */
     // eslint-disable-next-line complexity
     function install(config) {
-        if (
-            arguments.length > 1 ||
-            config instanceof Date ||
-            Array.isArray(config) ||
-            typeof config === "number"
-        ) {
-            throw new TypeError(
-                "lolex.install called with " +
-                    String(config) +
-                    " lolex 2.0+ requires an object parameter - see https://github.com/sinonjs/lolex"
-            );
-        }
-
         // eslint-disable-next-line no-param-reassign
         config = typeof config !== "undefined" ? config : {};
         config.shouldAdvanceTime = config.shouldAdvanceTime || false;

--- a/integration-test/fake-clock-integration-test.js
+++ b/integration-test/fake-clock-integration-test.js
@@ -18,7 +18,7 @@ if (!jsdom) {
 }
 
 var assert = require("@sinonjs/referee-sinon").assert;
-var lolex = require("../src/lolex-src");
+var FakeTimers = require("../src/fake-timers-src");
 var sinon = require("@sinonjs/referee-sinon").sinon;
 
 describe("withGlobal", function() {
@@ -28,12 +28,12 @@ describe("withGlobal", function() {
         var dom = new jsdom.JSDOM("", { runScripts: "dangerously" });
         jsdomGlobal = dom.window;
 
-        withGlobal = lolex.withGlobal(jsdomGlobal);
+        withGlobal = FakeTimers.withGlobal(jsdomGlobal);
         timers = Object.keys(withGlobal.timers);
     });
 
-    it("matches the normal lolex API", function() {
-        assert.equals(Object.keys(withGlobal), Object.keys(lolex));
+    it("matches the normal FakeTimers API", function() {
+        assert.equals(Object.keys(withGlobal), Object.keys(FakeTimers));
     });
 
     it("should support basic setTimeout", function() {
@@ -89,7 +89,7 @@ describe("globally configured browser objects", function() {
         };
         copyProps(window, global);
 
-        withGlobal = lolex.withGlobal(global);
+        withGlobal = FakeTimers.withGlobal(global);
     }
 
     function tearDownGlobal() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "lolex",
+  "name": "@sinonjs/fake-timers",
   "version": "5.1.2",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "lolex",
+  "name": "@sinonjs/fake-timers",
   "description": "Fake JavaScript timers",
   "version": "5.1.2",
-  "homepage": "http://github.com/sinonjs/lolex",
+  "homepage": "http://github.com/sinonjs/fake-timers",
   "author": "Christian Johansen",
   "repository": {
     "type": "git",
-    "url": "http://github.com/sinonjs/lolex.git"
+    "url": "http://github.com/sinonjs/fake-timers.git"
   },
   "bugs": {
     "mail": "christian@cjohansen.no",
-    "url": "http://github.com/sinonjs/lolex/issues"
+    "url": "http://github.com/sinonjs/fake-timers/issues"
   },
   "license": "BSD-3-Clause",
   "scripts": {
@@ -21,7 +21,7 @@
     "test-cloud": "mochify --wd --no-detect-globals --timeout=10000",
     "test-coverage": "nyc --all --reporter text --reporter html --reporter lcovonly npm run test-node",
     "test": "npm run lint && npm run test-node && npm run test-headless",
-    "bundle": "browserify --no-detect-globals -s lolex -o lolex.js src/lolex-src.js",
+    "bundle": "browserify --no-detect-globals -s FakeTimers -o fake-timers.js src/fake-timers-src.js",
     "prepublishOnly": "npm run bundle",
     "preversion": "./scripts/preversion.sh",
     "version": "./scripts/version.sh",
@@ -32,7 +32,7 @@
   },
   "files": [
     "src/",
-    "lolex.js"
+    "fake-timers.js"
   ],
   "devDependencies": {
     "@sinonjs/referee-sinon": "5.0.0",
@@ -72,8 +72,8 @@
       ]
     }
   },
-  "module": "./lolex.js",
-  "main": "./src/lolex-src.js",
+  "module": "./fake-timers.js",
+  "main": "./src/fake-timers-src.js",
   "dependencies": {
     "@sinonjs/commons": "^1.7.0"
   },
@@ -90,7 +90,7 @@
     "exclude": [
       "**/*-test.js",
       "coverage/**",
-      "lolex.js"
+      "fake-timers.js"
     ]
   }
 }

--- a/scripts/postversion.sh
+++ b/scripts/postversion.sh
@@ -2,11 +2,11 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $SCRIPT_DIR > /dev/null
 
-# check that that origin points to the sinonjs/lolex repo
-git remote -v | grep 'origin.*sinonjs/lolex.*push' > /dev/null
+# check that that origin points to the sinonjs/fake-timers repo
+git remote -v | grep 'origin.*sinonjs/fake-timers.*push' > /dev/null
 
 if [[ $? != 0 ]]; then
-    echo "'origin' doesn't point to the sinonjs/lolex repo. Fix tag push manually!"
+    echo "'origin' doesn't point to the sinonjs/fake-timers repo. Fix tag push manually!"
     exit 1
 fi
 

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -15,6 +15,6 @@ git add AUTHORS
 
 echo 'Build bundle'
 npm run bundle
-git add lolex.js
+git add fake-timers.js
 
 git commit -m "Updated release files for $PACKAGE_VERSION"

--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -1172,7 +1172,7 @@ function withGlobal(_global) {
                 });
             }
 
-            clock.performance.now = function lolexNow() {
+            clock.performance.now = function FakeTimersNow() {
                 var hrt = hrtime();
                 var millis = hrt[0] * 1000 + hrt[1] / 1e6;
                 return millis;
@@ -1192,24 +1192,11 @@ function withGlobal(_global) {
      * @param config.now {number|Date}  a number (in milliseconds) or a Date object (default epoch)
      * @param config.toFake {string[]} names of the methods that should be faked.
      * @param config.loopLimit {number} the maximum number of timers that will be run when calling runAll()
-     * @param config.shouldAdvanceTime {Boolean} tells lolex to increment mocked time automatically (default false)
+     * @param config.shouldAdvanceTime {Boolean} tells FakeTimers to increment mocked time automatically (default false)
      * @param config.advanceTimeDelta {Number} increment mocked time every <<advanceTimeDelta>> ms (default: 20ms)
      */
     // eslint-disable-next-line complexity
     function install(config) {
-        if (
-            arguments.length > 1 ||
-            config instanceof Date ||
-            Array.isArray(config) ||
-            typeof config === "number"
-        ) {
-            throw new TypeError(
-                "lolex.install called with " +
-                    String(config) +
-                    " lolex 2.0+ requires an object parameter - see https://github.com/sinonjs/lolex"
-            );
-        }
-
         // eslint-disable-next-line no-param-reassign
         config = typeof config !== "undefined" ? config : {};
         config.shouldAdvanceTime = config.shouldAdvanceTime || false;

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -8,12 +8,12 @@
 "use strict";
 
 /*
- * FIXME This is an interim hack to break a circular dependency between lolex,
+ * FIXME This is an interim hack to break a circular dependency between FakeTimers,
  * nise and sinon.
  *
- * 1. Load lolex firt, without defining global, verifying the ReferenceError is gone.
+ * 1. Load FakeTimers first, without defining global, verifying the ReferenceError is gone.
  */
-var lolex = require("../src/lolex-src");
+var FakeTimers = require("../src/fake-timers-src");
 
 /*
  * 2. Define global, if missing.
@@ -30,7 +30,7 @@ var refute = require("@sinonjs/referee-sinon").refute;
 var sinon = require("@sinonjs/referee-sinon").sinon;
 
 var globalObject = typeof global !== "undefined" ? global : window;
-globalObject.lolex = lolex; // For testing eval
+globalObject.FakeTimers = FakeTimers; // For testing eval
 
 var GlobalDate = Date;
 
@@ -60,7 +60,7 @@ describe("issue #59", function() {
     var clock;
 
     it("should install and uninstall the clock on a custom target", function() {
-        clock = lolex.install(context);
+        clock = FakeTimers.install(context);
         // this would throw an error before issue #59 was fixed
         clock.uninstall();
     });
@@ -69,7 +69,7 @@ describe("issue #59", function() {
 describe("issue #73", function() {
     it("should install with date object", function() {
         var date = new Date("2015-09-25");
-        var clock = lolex.install({ now: date });
+        var clock = FakeTimers.install({ now: date });
         assert.same(clock.now, 1443139200000);
         clock.uninstall();
     });
@@ -78,7 +78,7 @@ describe("issue #73", function() {
 describe("issue #67", function() {
     // see https://nodejs.org/api/timers.html
     it("should overflow to 1 on very big timeouts", function() {
-        var clock = lolex.install();
+        var clock = FakeTimers.install();
         var stub1 = sinon.stub();
         var stub2 = sinon.stub();
 
@@ -97,7 +97,7 @@ describe("issue #67", function() {
     });
 
     it("should overflow to interval 1 on very big timeouts", function() {
-        var clock = lolex.install();
+        var clock = FakeTimers.install();
         var stub = sinon.stub();
 
         clock.setInterval(stub, 214748334700);
@@ -108,7 +108,7 @@ describe("issue #67", function() {
     });
 
     it("should execute setTimeout smaller than 1", function() {
-        var clock = lolex.install();
+        var clock = FakeTimers.install();
         var stub1 = sinon.stub();
 
         clock.setTimeout(stub1, 0.5);
@@ -119,7 +119,7 @@ describe("issue #67", function() {
     });
 
     it("executes setTimeout with negative duration as if it has zero delay", function() {
-        var clock = lolex.install();
+        var clock = FakeTimers.install();
         var stub1 = sinon.stub();
 
         clock.setTimeout(stub1, -10);
@@ -132,7 +132,7 @@ describe("issue #67", function() {
 
 describe("issue sinon#1852", function() {
     it("throws when creating a clock and global has no Date", function() {
-        var clock = lolex.withGlobal({
+        var clock = FakeTimers.withGlobal({
             setTimeout: function() {},
             clearTimeout: function() {}
         });
@@ -154,7 +154,7 @@ describe("issue #207 - nanosecond round-off errors on high-res timer", function(
 
     if (hrtimePresent) {
         it("should not round off nanosecond arithmetic on hrtime - case 1", function() {
-            clock = lolex.install();
+            clock = FakeTimers.install();
 
             clock.tick(1022.7791);
 
@@ -163,7 +163,7 @@ describe("issue #207 - nanosecond round-off errors on high-res timer", function(
         });
 
         it("should not round off nanosecond arithmetic on hrtime - case 2", function() {
-            clock = lolex.install({
+            clock = FakeTimers.install({
                 now: new Date("2018-09-12T08:58:33.742000000Z").getTime(),
                 toFake: ["hrtime"]
             });
@@ -175,7 +175,7 @@ describe("issue #207 - nanosecond round-off errors on high-res timer", function(
         });
 
         it("should truncate sub-nanosecond ticks", function() {
-            clock = lolex.install();
+            clock = FakeTimers.install();
             clock.tick(0.123456789);
 
             var nanos = clock.hrtime()[1];
@@ -184,14 +184,14 @@ describe("issue #207 - nanosecond round-off errors on high-res timer", function(
     }
 
     it("should always set 'now' to an integer value when ticking with sub-millisecond precision", function() {
-        clock = lolex.install();
+        clock = FakeTimers.install();
         clock.tick(2.993);
 
         assert.equals(clock.now, 2);
     });
 
     it("should adjust adjust the 'now' value when the nano-remainder overflows", function() {
-        clock = lolex.install();
+        clock = FakeTimers.install();
         clock.tick(0.993);
         clock.tick(0.5);
 
@@ -199,23 +199,23 @@ describe("issue #207 - nanosecond round-off errors on high-res timer", function(
     });
 
     it("should floor negative now values", function() {
-        clock = lolex.install({ now: -1.2 });
+        clock = FakeTimers.install({ now: -1.2 });
 
         assert.equals(clock.now, -2);
     });
 
     it("should floor start times", function() {
-        clock = lolex.install({ now: 1.2 });
+        clock = FakeTimers.install({ now: 1.2 });
         assert.equals(clock.now, 1);
     });
 
     it("should floor negative start times", function() {
-        clock = lolex.install({ now: -1.2 });
+        clock = FakeTimers.install({ now: -1.2 });
         assert.equals(clock.now, -2);
     });
 
     it("should handle ticks on the negative side of the Epoch", function() {
-        clock = lolex.install({ now: -2 });
+        clock = FakeTimers.install({ now: -2 });
         clock.tick(0.8); // -1.2
         clock.tick(0.5); // -0.7
 
@@ -223,7 +223,7 @@ describe("issue #207 - nanosecond round-off errors on high-res timer", function(
     });
 
     it("should handle multiple non-integer ticks", function() {
-        clock = lolex.install({ now: -2 });
+        clock = FakeTimers.install({ now: -2 });
         clock.tick(1.1); // -0.9
         clock.tick(0.5);
         clock.tick(0.5); // 0.1
@@ -241,22 +241,22 @@ describe("issue #sinonjs/2086 - don't install setImmediate in unsupported enviro
         });
 
         it("should not install setImmediate", function() {
-            clock = lolex.install();
+            clock = FakeTimers.install();
 
             assert.isUndefined(global.setImmediate);
         });
     }
 });
 
-describe("lolex", function() {
+describe("FakeTimers", function() {
     describe("setTimeout", function() {
         beforeEach(function() {
-            this.clock = lolex.createClock();
-            lolex.evalCalled = false;
+            this.clock = FakeTimers.createClock();
+            FakeTimers.evalCalled = false;
         });
 
         afterEach(function() {
-            delete lolex.evalCalled;
+            delete FakeTimers.evalCalled;
         });
 
         it("throws if no arguments", function() {
@@ -285,8 +285,8 @@ describe("lolex", function() {
         });
 
         it("sets timers on instance", function() {
-            var clock1 = lolex.createClock();
-            var clock2 = lolex.createClock();
+            var clock1 = FakeTimers.createClock();
+            var clock2 = FakeTimers.createClock();
             var stubs = [sinon.stub(), sinon.stub()];
 
             clock1.setTimeout(stubs[0], 100);
@@ -299,31 +299,31 @@ describe("lolex", function() {
 
         it("parses numeric string times", function() {
             this.clock.setTimeout(function() {
-                lolex.evalCalled = true;
+                FakeTimers.evalCalled = true;
             }, "10");
             this.clock.tick(10);
 
-            assert(lolex.evalCalled);
+            assert(FakeTimers.evalCalled);
         });
 
         it("parses no-numeric string times", function() {
             this.clock.setTimeout(function() {
-                lolex.evalCalled = true;
+                FakeTimers.evalCalled = true;
             }, "string");
             this.clock.tick(10);
 
-            assert(lolex.evalCalled);
+            assert(FakeTimers.evalCalled);
         });
 
         it("evals non-function callbacks", function() {
-            this.clock.setTimeout("lolex.evalCalled = true", 10);
+            this.clock.setTimeout("FakeTimers.evalCalled = true", 10);
             this.clock.tick(10);
 
-            assert(lolex.evalCalled);
+            assert(FakeTimers.evalCalled);
         });
 
         it("passes setTimeout parameters", function() {
-            var clock = lolex.createClock();
+            var clock = FakeTimers.createClock();
             var stub = sinon.stub();
 
             clock.setTimeout(stub, 2, "the first", "the second");
@@ -334,7 +334,7 @@ describe("lolex", function() {
         });
 
         it("calls correct timeout on recursive tick", function() {
-            var clock = lolex.createClock();
+            var clock = FakeTimers.createClock();
             var stub = sinon.stub();
             var recurseCallback = function() {
                 clock.tick(100);
@@ -348,7 +348,7 @@ describe("lolex", function() {
         });
 
         it("does not depend on this", function() {
-            var clock = lolex.createClock();
+            var clock = FakeTimers.createClock();
             var stub = sinon.stub();
             var setTimeout = clock.setTimeout;
 
@@ -453,7 +453,7 @@ describe("lolex", function() {
                 this.skip();
             }
 
-            this.clock = lolex.createClock();
+            this.clock = FakeTimers.createClock();
         });
 
         it("returns numeric id or object with numeric id", function() {
@@ -484,8 +484,8 @@ describe("lolex", function() {
         });
 
         it("manages separate timers per clock instance", function() {
-            var clock1 = lolex.createClock();
-            var clock2 = lolex.createClock();
+            var clock1 = FakeTimers.createClock();
+            var clock2 = FakeTimers.createClock();
             var stubs = [sinon.stub(), sinon.stub()];
 
             clock1.setImmediate(stubs[0]);
@@ -535,7 +535,7 @@ describe("lolex", function() {
                 this.skip();
             }
 
-            this.clock = lolex.createClock();
+            this.clock = FakeTimers.createClock();
         });
 
         it("removes immediate callbacks", function() {
@@ -587,7 +587,7 @@ describe("lolex", function() {
 
     describe("countTimers", function() {
         beforeEach(function() {
-            this.clock = lolex.createClock();
+            this.clock = FakeTimers.createClock();
         });
 
         it("return zero for a fresh clock", function() {
@@ -610,7 +610,7 @@ describe("lolex", function() {
 
     describe("tick", function() {
         beforeEach(function() {
-            this.clock = lolex.install({ now: 0 });
+            this.clock = FakeTimers.install({ now: 0 });
         });
 
         afterEach(function() {
@@ -1029,7 +1029,7 @@ describe("lolex", function() {
     if (typeof global.Promise !== "undefined") {
         describe("tickAsync", function() {
             beforeEach(function() {
-                this.clock = lolex.install();
+                this.clock = FakeTimers.install();
             });
 
             afterEach(function() {
@@ -1719,7 +1719,7 @@ describe("lolex", function() {
 
     describe("next", function() {
         beforeEach(function() {
-            this.clock = lolex.install({ now: 0 });
+            this.clock = FakeTimers.install({ now: 0 });
         });
 
         afterEach(function() {
@@ -1916,7 +1916,7 @@ describe("lolex", function() {
     if (typeof global.Promise !== "undefined") {
         describe("nextAsync", function() {
             beforeEach(function() {
-                this.clock = lolex.install();
+                this.clock = FakeTimers.install();
             });
 
             afterEach(function() {
@@ -2290,12 +2290,12 @@ describe("lolex", function() {
 
     describe("runAll", function() {
         it("if there are no timers just return", function() {
-            this.clock = lolex.createClock();
+            this.clock = FakeTimers.createClock();
             this.clock.runAll();
         });
 
         it("runs all timers", function() {
-            this.clock = lolex.createClock();
+            this.clock = FakeTimers.createClock();
             var spies = [sinon.spy(), sinon.spy()];
             this.clock.setTimeout(spies[0], 10);
             this.clock.setTimeout(spies[1], 50);
@@ -2307,7 +2307,7 @@ describe("lolex", function() {
         });
 
         it("new timers added while running are also run", function() {
-            this.clock = lolex.createClock();
+            this.clock = FakeTimers.createClock();
             var test = this;
             var spies = [
                 sinon.spy(function() {
@@ -2326,7 +2326,7 @@ describe("lolex", function() {
         });
 
         it("throws before allowing infinite recursion", function() {
-            this.clock = lolex.createClock();
+            this.clock = FakeTimers.createClock();
             var test = this;
             var recursiveCallback = function() {
                 test.clock.setTimeout(recursiveCallback, 10);
@@ -2340,7 +2340,7 @@ describe("lolex", function() {
         });
 
         it("the loop limit can be set when creating a clock", function() {
-            this.clock = lolex.createClock(0, 1);
+            this.clock = FakeTimers.createClock(0, 1);
             var test = this;
 
             var spies = [sinon.spy(), sinon.spy()];
@@ -2353,7 +2353,7 @@ describe("lolex", function() {
         });
 
         it("the loop limit can be set when installing a clock", function() {
-            this.clock = lolex.install({ loopLimit: 1 });
+            this.clock = FakeTimers.install({ loopLimit: 1 });
             var test = this;
 
             var spies = [sinon.spy(), sinon.spy()];
@@ -2371,12 +2371,12 @@ describe("lolex", function() {
     if (typeof global.Promise !== "undefined") {
         describe("runAllAsync", function() {
             it("if there are no timers just return", function() {
-                this.clock = lolex.createClock();
+                this.clock = FakeTimers.createClock();
                 return this.clock.runAllAsync();
             });
 
             it("runs all timers", function() {
-                this.clock = lolex.createClock();
+                this.clock = FakeTimers.createClock();
                 var spies = [sinon.spy(), sinon.spy()];
                 this.clock.setTimeout(spies[0], 10);
                 this.clock.setTimeout(spies[1], 50);
@@ -2388,7 +2388,7 @@ describe("lolex", function() {
             });
 
             it("new timers added while running are also run", function() {
-                this.clock = lolex.createClock();
+                this.clock = FakeTimers.createClock();
                 var test = this;
                 var spies = [
                     sinon.spy(function() {
@@ -2407,7 +2407,7 @@ describe("lolex", function() {
             });
 
             it("new timers added in promises while running are also run", function() {
-                this.clock = lolex.createClock();
+                this.clock = FakeTimers.createClock();
                 var test = this;
                 var spies = [
                     sinon.spy(function() {
@@ -2428,7 +2428,7 @@ describe("lolex", function() {
             });
 
             it("throws before allowing infinite recursion", function() {
-                this.clock = lolex.createClock(0, 100);
+                this.clock = FakeTimers.createClock(0, 100);
                 var test = this;
                 var recursiveCallback = function() {
                     test.clock.setTimeout(recursiveCallback, 10);
@@ -2446,7 +2446,7 @@ describe("lolex", function() {
             });
 
             it("throws before allowing infinite recursion from promises", function() {
-                this.clock = lolex.createClock(0, 100);
+                this.clock = FakeTimers.createClock(0, 100);
                 var test = this;
                 var recursiveCallback = function() {
                     global.Promise.resolve().then(function() {
@@ -2466,7 +2466,7 @@ describe("lolex", function() {
             });
 
             it("the loop limit can be set when creating a clock", function() {
-                this.clock = lolex.createClock(0, 1);
+                this.clock = FakeTimers.createClock(0, 1);
                 var test = this;
                 var catchSpy = sinon.spy();
 
@@ -2483,7 +2483,7 @@ describe("lolex", function() {
             });
 
             it("the loop limit can be set when installing a clock", function() {
-                this.clock = lolex.install({ loopLimit: 1 });
+                this.clock = FakeTimers.install({ loopLimit: 1 });
                 var test = this;
                 var catchSpy = sinon.spy();
 
@@ -2502,7 +2502,7 @@ describe("lolex", function() {
             });
 
             it("should settle user-created promises", function() {
-                this.clock = lolex.createClock();
+                this.clock = FakeTimers.createClock();
                 var spy = sinon.spy();
 
                 this.clock.setTimeout(function() {
@@ -2515,7 +2515,7 @@ describe("lolex", function() {
             });
 
             it("should settle nested user-created promises", function() {
-                this.clock = lolex.createClock();
+                this.clock = FakeTimers.createClock();
                 var spy = sinon.spy();
 
                 this.clock.setTimeout(function() {
@@ -2532,7 +2532,7 @@ describe("lolex", function() {
             });
 
             it("should settle local promises before firing timers", function() {
-                this.clock = lolex.createClock();
+                this.clock = FakeTimers.createClock();
                 var spies = [sinon.spy(), sinon.spy()];
 
                 global.Promise.resolve().then(spies[0]);
@@ -2545,7 +2545,7 @@ describe("lolex", function() {
             });
 
             it("should settle user-created promises before firing more timers", function() {
-                this.clock = lolex.createClock();
+                this.clock = FakeTimers.createClock();
                 var spies = [sinon.spy(), sinon.spy()];
 
                 this.clock.setTimeout(function() {
@@ -2563,7 +2563,7 @@ describe("lolex", function() {
 
     describe("runToLast", function() {
         it("returns current time when there are no timers", function() {
-            this.clock = lolex.createClock();
+            this.clock = FakeTimers.createClock();
 
             var time = this.clock.runToLast();
 
@@ -2571,7 +2571,7 @@ describe("lolex", function() {
         });
 
         it("runs all existing timers", function() {
-            this.clock = lolex.createClock();
+            this.clock = FakeTimers.createClock();
             var spies = [sinon.spy(), sinon.spy()];
             this.clock.setTimeout(spies[0], 10);
             this.clock.setTimeout(spies[1], 50);
@@ -2583,7 +2583,7 @@ describe("lolex", function() {
         });
 
         it("returns time of the last timer", function() {
-            this.clock = lolex.createClock();
+            this.clock = FakeTimers.createClock();
             var spies = [sinon.spy(), sinon.spy()];
             this.clock.setTimeout(spies[0], 10);
             this.clock.setTimeout(spies[1], 50);
@@ -2594,7 +2594,7 @@ describe("lolex", function() {
         });
 
         it("runs all existing timers when two timers are matched for being last", function() {
-            this.clock = lolex.createClock();
+            this.clock = FakeTimers.createClock();
             var spies = [sinon.spy(), sinon.spy()];
             this.clock.setTimeout(spies[0], 10);
             this.clock.setTimeout(spies[1], 10);
@@ -2606,7 +2606,7 @@ describe("lolex", function() {
         });
 
         it("new timers added with a call time later than the last existing timer are NOT run", function() {
-            this.clock = lolex.createClock();
+            this.clock = FakeTimers.createClock();
             var test = this;
             var spies = [
                 sinon.spy(function() {
@@ -2625,7 +2625,7 @@ describe("lolex", function() {
         });
 
         it("new timers added with a call time earlier than the last existing timer are run", function() {
-            this.clock = lolex.createClock();
+            this.clock = FakeTimers.createClock();
             var test = this;
             var spies = [
                 sinon.spy(),
@@ -2647,7 +2647,7 @@ describe("lolex", function() {
         });
 
         it("new timers cannot cause an infinite loop", function() {
-            this.clock = lolex.createClock();
+            this.clock = FakeTimers.createClock();
             var test = this;
             var spy = sinon.spy();
             var recursiveCallback = function() {
@@ -2663,7 +2663,7 @@ describe("lolex", function() {
         });
 
         it("should support clocks with start time", function() {
-            this.clock = lolex.createClock(200);
+            this.clock = FakeTimers.createClock(200);
             var that = this;
             var invocations = 0;
 
@@ -2681,7 +2681,7 @@ describe("lolex", function() {
     if (typeof global.Promise !== "undefined") {
         describe("runToLastAsync", function() {
             it("returns current time when there are no timers", function() {
-                this.clock = lolex.createClock();
+                this.clock = FakeTimers.createClock();
 
                 return this.clock.runToLastAsync().then(function(time) {
                     assert.equals(time, 0);
@@ -2689,7 +2689,7 @@ describe("lolex", function() {
             });
 
             it("runs all existing timers", function() {
-                this.clock = lolex.createClock();
+                this.clock = FakeTimers.createClock();
                 var spies = [sinon.spy(), sinon.spy()];
                 this.clock.setTimeout(spies[0], 10);
                 this.clock.setTimeout(spies[1], 50);
@@ -2701,7 +2701,7 @@ describe("lolex", function() {
             });
 
             it("returns time of the last timer", function() {
-                this.clock = lolex.createClock();
+                this.clock = FakeTimers.createClock();
                 var spies = [sinon.spy(), sinon.spy()];
                 this.clock.setTimeout(spies[0], 10);
                 this.clock.setTimeout(spies[1], 50);
@@ -2712,7 +2712,7 @@ describe("lolex", function() {
             });
 
             it("runs all existing timers when two timers are matched for being last", function() {
-                this.clock = lolex.createClock();
+                this.clock = FakeTimers.createClock();
                 var spies = [sinon.spy(), sinon.spy()];
                 this.clock.setTimeout(spies[0], 10);
                 this.clock.setTimeout(spies[1], 10);
@@ -2724,7 +2724,7 @@ describe("lolex", function() {
             });
 
             it("new timers added with a call time later than the last existing timer are NOT run", function() {
-                this.clock = lolex.createClock();
+                this.clock = FakeTimers.createClock();
                 var test = this;
                 var spies = [
                     sinon.spy(function() {
@@ -2746,7 +2746,7 @@ describe("lolex", function() {
                 "new timers added from a promise with a call time later than the last existing timer" +
                     "are NOT run",
                 function() {
-                    this.clock = lolex.createClock();
+                    this.clock = FakeTimers.createClock();
                     var test = this;
                     var spies = [
                         sinon.spy(function() {
@@ -2768,7 +2768,7 @@ describe("lolex", function() {
             );
 
             it("new timers added with a call time ealier than the last existing timer are run", function() {
-                this.clock = lolex.createClock();
+                this.clock = FakeTimers.createClock();
                 var test = this;
                 var spies = [
                     sinon.spy(),
@@ -2793,7 +2793,7 @@ describe("lolex", function() {
                 "new timers added from a promise with a call time ealier than the last existing timer" +
                     "are run",
                 function() {
-                    this.clock = lolex.createClock();
+                    this.clock = FakeTimers.createClock();
                     var test = this;
                     var spies = [
                         sinon.spy(),
@@ -2818,7 +2818,7 @@ describe("lolex", function() {
             );
 
             it("new timers cannot cause an infinite loop", function() {
-                this.clock = lolex.createClock();
+                this.clock = FakeTimers.createClock();
                 var test = this;
                 var spy = sinon.spy();
                 var recursiveCallback = function() {
@@ -2834,7 +2834,7 @@ describe("lolex", function() {
             });
 
             it("new timers created from promises cannot cause an infinite loop", function() {
-                this.clock = lolex.createClock();
+                this.clock = FakeTimers.createClock();
                 var test = this;
                 var spy = sinon.spy();
                 var recursiveCallback = function() {
@@ -2852,7 +2852,7 @@ describe("lolex", function() {
             });
 
             it("should settle user-created promises", function() {
-                this.clock = lolex.createClock();
+                this.clock = FakeTimers.createClock();
                 var spy = sinon.spy();
 
                 this.clock.setTimeout(function() {
@@ -2865,7 +2865,7 @@ describe("lolex", function() {
             });
 
             it("should settle nested user-created promises", function() {
-                this.clock = lolex.createClock();
+                this.clock = FakeTimers.createClock();
                 var spy = sinon.spy();
 
                 this.clock.setTimeout(function() {
@@ -2882,7 +2882,7 @@ describe("lolex", function() {
             });
 
             it("should settle local promises before firing timers", function() {
-                this.clock = lolex.createClock();
+                this.clock = FakeTimers.createClock();
                 var spies = [sinon.spy(), sinon.spy()];
 
                 global.Promise.resolve().then(spies[0]);
@@ -2895,7 +2895,7 @@ describe("lolex", function() {
             });
 
             it("should settle user-created promises before firing more timers", function() {
-                this.clock = lolex.createClock();
+                this.clock = FakeTimers.createClock();
                 var spies = [sinon.spy(), sinon.spy()];
 
                 this.clock.setTimeout(function() {
@@ -2913,7 +2913,7 @@ describe("lolex", function() {
 
     describe("clearTimeout", function() {
         beforeEach(function() {
-            this.clock = lolex.createClock();
+            this.clock = FakeTimers.createClock();
         });
 
         it("removes timeout", function() {
@@ -2988,7 +2988,7 @@ describe("lolex", function() {
 
     describe("reset", function() {
         beforeEach(function() {
-            this.clock = lolex.createClock();
+            this.clock = FakeTimers.createClock();
         });
 
         it("empties timeouts queue", function() {
@@ -3004,7 +3004,7 @@ describe("lolex", function() {
         });
 
         it("resets to the time install with - issue #183", function() {
-            var clock = lolex.install({ now: 10000 });
+            var clock = FakeTimers.install({ now: 10000 });
             clock.reset();
             assert.equals(clock.now, 10000);
             clock.uninstall();
@@ -3015,7 +3015,7 @@ describe("lolex", function() {
                 this.skip();
             }
 
-            var clock = lolex.createClock();
+            var clock = FakeTimers.createClock();
             clock.tick(100);
             assert.equals(clock.hrtime(), [0, 100 * 1e6]);
             clock.reset();
@@ -3025,7 +3025,7 @@ describe("lolex", function() {
 
     describe("setInterval", function() {
         beforeEach(function() {
-            this.clock = lolex.createClock();
+            this.clock = FakeTimers.createClock();
         });
 
         it("throws if no arguments", function() {
@@ -3100,7 +3100,7 @@ describe("lolex", function() {
         });
 
         it("passes setTimeout parameters", function() {
-            var clock = lolex.createClock();
+            var clock = FakeTimers.createClock();
             var stub = sinon.stub();
 
             clock.setInterval(stub, 2, "the first", "the second");
@@ -3113,7 +3113,7 @@ describe("lolex", function() {
 
     describe("clearInterval", function() {
         beforeEach(function() {
-            this.clock = lolex.createClock();
+            this.clock = FakeTimers.createClock();
         });
 
         it("removes interval", function() {
@@ -3180,7 +3180,7 @@ describe("lolex", function() {
     describe("date", function() {
         beforeEach(function() {
             this.now = new GlobalDate().getTime() - 3000;
-            this.clock = lolex.createClock(this.now);
+            this.clock = FakeTimers.createClock(this.now);
             this.Date = global.Date;
         });
 
@@ -3401,14 +3401,14 @@ describe("lolex", function() {
         });
 
         it("returns clock object", function() {
-            this.clock = lolex.install();
+            this.clock = FakeTimers.install();
 
             assert.isObject(this.clock);
             assert.isFunction(this.clock.tick);
         });
 
         it("has clock property", function() {
-            this.clock = lolex.install();
+            this.clock = FakeTimers.install();
 
             assert.same(setTimeout.clock, this.clock);
             assert.same(clearTimeout.clock, this.clock);
@@ -3418,23 +3418,23 @@ describe("lolex", function() {
         });
 
         it("takes an object parameter", function() {
-            this.clock = lolex.install({});
+            this.clock = FakeTimers.install({});
         });
 
         it("throws a TypeError on a number parameter", function() {
             assert.exception(function() {
-                this.clock = lolex.install(0);
+                this.clock = FakeTimers.install(0);
             });
         });
 
         it("sets initial timestamp", function() {
-            this.clock = lolex.install({ now: 1400 });
+            this.clock = FakeTimers.install({ now: 1400 });
 
             assert.equals(this.clock.now, 1400);
         });
 
         it("replaces global setTimeout", function() {
-            this.clock = lolex.install();
+            this.clock = FakeTimers.install();
             var stub = sinon.stub();
 
             setTimeout(stub, 1000);
@@ -3444,7 +3444,7 @@ describe("lolex", function() {
         });
 
         it("global fake setTimeout should return id", function() {
-            this.clock = lolex.install();
+            this.clock = FakeTimers.install();
             var stub = sinon.stub();
 
             var to = setTimeout(stub, 1000);
@@ -3459,7 +3459,7 @@ describe("lolex", function() {
         });
 
         it("global fake setTimeout().ref() should return timer", function() {
-            this.clock = lolex.install();
+            this.clock = FakeTimers.install();
             var stub = sinon.stub();
 
             if (typeof setTimeout(NOOP, 0) === "object") {
@@ -3471,7 +3471,7 @@ describe("lolex", function() {
         });
 
         it("global fake setTimeout().unref() should return timer", function() {
-            this.clock = lolex.install();
+            this.clock = FakeTimers.install();
             var stub = sinon.stub();
 
             if (typeof setTimeout(NOOP, 0) === "object") {
@@ -3483,7 +3483,7 @@ describe("lolex", function() {
         });
 
         it("global fake setTimeout().refresh() should return timer", function() {
-            this.clock = lolex.install();
+            this.clock = FakeTimers.install();
             var stub = sinon.stub();
 
             if (typeof setTimeout(NOOP, 0) === "object") {
@@ -3495,7 +3495,7 @@ describe("lolex", function() {
         });
 
         it("replaces global clearTimeout", function() {
-            this.clock = lolex.install();
+            this.clock = FakeTimers.install();
             var stub = sinon.stub();
 
             clearTimeout(setTimeout(stub, 1000));
@@ -3505,7 +3505,7 @@ describe("lolex", function() {
         });
 
         it("uninstalls global setTimeout", function() {
-            this.clock = lolex.install();
+            this.clock = FakeTimers.install();
             var stub = sinon.stub();
             this.clock.uninstall();
 
@@ -3513,19 +3513,19 @@ describe("lolex", function() {
             this.clock.tick(1000);
 
             assert.isFalse(stub.called);
-            assert.same(setTimeout, lolex.timers.setTimeout);
+            assert.same(setTimeout, FakeTimers.timers.setTimeout);
         });
 
         it("uninstalls global clearTimeout", function() {
-            this.clock = lolex.install();
+            this.clock = FakeTimers.install();
             sinon.stub();
             this.clock.uninstall();
 
-            assert.same(clearTimeout, lolex.timers.clearTimeout);
+            assert.same(clearTimeout, FakeTimers.timers.clearTimeout);
         });
 
         it("replaces global setInterval", function() {
-            this.clock = lolex.install();
+            this.clock = FakeTimers.install();
             var stub = sinon.stub();
 
             setInterval(stub, 500);
@@ -3535,7 +3535,7 @@ describe("lolex", function() {
         });
 
         it("replaces global clearInterval", function() {
-            this.clock = lolex.install();
+            this.clock = FakeTimers.install();
             var stub = sinon.stub();
 
             clearInterval(setInterval(stub, 500));
@@ -3545,7 +3545,7 @@ describe("lolex", function() {
         });
 
         it("uninstalls global setInterval", function() {
-            this.clock = lolex.install();
+            this.clock = FakeTimers.install();
             var stub = sinon.stub();
             this.clock.uninstall();
 
@@ -3553,20 +3553,20 @@ describe("lolex", function() {
             this.clock.tick(1000);
 
             assert.isFalse(stub.called);
-            assert.same(setInterval, lolex.timers.setInterval);
+            assert.same(setInterval, FakeTimers.timers.setInterval);
         });
 
         it("uninstalls global clearInterval", function() {
-            this.clock = lolex.install();
+            this.clock = FakeTimers.install();
             sinon.stub();
             this.clock.uninstall();
 
-            assert.same(clearInterval, lolex.timers.clearInterval);
+            assert.same(clearInterval, FakeTimers.timers.clearInterval);
         });
 
         if (hrtimePresent) {
             it("replaces global process.hrtime", function() {
-                this.clock = lolex.install();
+                this.clock = FakeTimers.install();
                 var prev = process.hrtime();
                 this.clock.tick(1000);
                 var result = process.hrtime(prev);
@@ -3575,9 +3575,9 @@ describe("lolex", function() {
             });
 
             it("uninstalls global process.hrtime", function() {
-                this.clock = lolex.install();
+                this.clock = FakeTimers.install();
                 this.clock.uninstall();
-                assert.same(process.hrtime, lolex.timers.hrtime);
+                assert.same(process.hrtime, FakeTimers.timers.hrtime);
                 var prev = process.hrtime();
                 this.clock.tick(1000);
                 var result = process.hrtime(prev);
@@ -3587,7 +3587,7 @@ describe("lolex", function() {
 
         if (performanceNowPresent) {
             it("replaces global performance.now", function() {
-                this.clock = lolex.install();
+                this.clock = FakeTimers.install();
                 var prev = performance.now();
                 this.clock.tick(1000);
                 var next = performance.now();
@@ -3597,7 +3597,7 @@ describe("lolex", function() {
 
             it("uninstalls global performance.now", function() {
                 var oldNow = performance.now;
-                this.clock = lolex.install();
+                this.clock = FakeTimers.install();
                 assert.same(performance.now, this.clock.performance.now);
                 this.clock.uninstall();
                 assert.same(performance.now, oldNow);
@@ -3605,8 +3605,8 @@ describe("lolex", function() {
 
             /* For instance, Safari 9 has performance.now(), but no performance.mark() */
             if (performanceMarkPresent) {
-                it("should let performance.mark still be callable after lolex.install() (#136)", function() {
-                    this.clock = lolex.install();
+                it("should let performance.mark still be callable after FakeTimers.install() (#136)", function() {
+                    this.clock = FakeTimers.install();
                     refute.exception(function() {
                         global.performance.mark("a name");
                     });
@@ -3620,7 +3620,7 @@ describe("lolex", function() {
                 Performance.prototype.someFunc2 = function() {};
                 Performance.prototype.someFunc3 = function() {};
 
-                this.clock = lolex.install();
+                this.clock = FakeTimers.install();
 
                 assert.isFunction(performance.someFunc1);
                 assert.isFunction(performance.someFunc2);
@@ -3642,7 +3642,7 @@ describe("lolex", function() {
                 Performance.prototype.getEntriesByName = noop;
                 Performance.prototype.getEntriesByType = noop;
 
-                this.clock = lolex.install();
+                this.clock = FakeTimers.install();
 
                 assert.equals(performance.getEntries(), []);
                 assert.equals(performance.getEntriesByName(), []);
@@ -3670,7 +3670,10 @@ describe("lolex", function() {
                     delete global.tick;
                     Object.getPrototypeOf(global).tick = function() {};
 
-                    this.clock = lolex.install({ now: 0, toFake: ["tick"] });
+                    this.clock = FakeTimers.install({
+                        now: 0,
+                        toFake: ["tick"]
+                    });
                     assert.isTrue(global.hasOwnProperty("tick"));
                     this.clock.uninstall();
 
@@ -3686,7 +3689,7 @@ describe("lolex", function() {
             // Directly give the global object a tick method
             global.tick = NOOP;
 
-            this.clock = lolex.install({ now: 0, toFake: ["tick"] });
+            this.clock = FakeTimers.install({ now: 0, toFake: ["tick"] });
             assert.isTrue(global.hasOwnProperty("tick"));
             this.clock.uninstall();
 
@@ -3695,15 +3698,15 @@ describe("lolex", function() {
         });
 
         it("fakes Date constructor", function() {
-            this.clock = lolex.install({ now: 0 });
+            this.clock = FakeTimers.install({ now: 0 });
             var now = new Date();
 
-            refute.same(Date, lolex.timers.Date);
+            refute.same(Date, FakeTimers.timers.Date);
             assert.equals(now.getTime(), 0);
         });
 
         it("fake Date constructor should mirror Date's properties", function() {
-            this.clock = lolex.install({ now: 0 });
+            this.clock = FakeTimers.install({ now: 0 });
 
             assert(Boolean(Date.parse));
             assert(Boolean(Date.UTC));
@@ -3711,14 +3714,14 @@ describe("lolex", function() {
 
         it("decide on Date.now support at call-time when supported", function() {
             global.Date.now = NOOP;
-            this.clock = lolex.install({ now: 0 });
+            this.clock = FakeTimers.install({ now: 0 });
 
             assert.equals(typeof Date.now, "function");
         });
 
         it("decide on Date.now support at call-time when unsupported", function() {
             global.Date.now = undefined;
-            this.clock = lolex.install({ now: 0 });
+            this.clock = FakeTimers.install({ now: 0 });
 
             assert.isUndefined(Date.now);
         });
@@ -3728,48 +3731,48 @@ describe("lolex", function() {
                 return "";
             };
             global.Date.format = f;
-            this.clock = lolex.install();
+            this.clock = FakeTimers.install();
 
             assert.equals(Date.format, f);
         });
 
         it("uninstalls Date constructor", function() {
-            this.clock = lolex.install({ now: 0 });
+            this.clock = FakeTimers.install({ now: 0 });
             this.clock.uninstall();
 
-            assert.same(GlobalDate, lolex.timers.Date);
+            assert.same(GlobalDate, FakeTimers.timers.Date);
         });
 
         it("fakes provided methods", function() {
-            this.clock = lolex.install({
+            this.clock = FakeTimers.install({
                 now: 0,
                 toFake: ["setTimeout", "Date"]
             });
 
-            refute.same(setTimeout, lolex.timers.setTimeout);
-            refute.same(Date, lolex.timers.Date);
+            refute.same(setTimeout, FakeTimers.timers.setTimeout);
+            refute.same(Date, FakeTimers.timers.Date);
         });
 
         it("resets faked methods", function() {
-            this.clock = lolex.install({
+            this.clock = FakeTimers.install({
                 now: 0,
                 toFake: ["setTimeout", "Date"]
             });
             this.clock.uninstall();
 
-            assert.same(setTimeout, lolex.timers.setTimeout);
-            assert.same(Date, lolex.timers.Date);
+            assert.same(setTimeout, FakeTimers.timers.setTimeout);
+            assert.same(Date, FakeTimers.timers.Date);
         });
 
         it("does not fake methods not provided", function() {
-            this.clock = lolex.install({
+            this.clock = FakeTimers.install({
                 now: 0,
                 toFake: ["setTimeout", "Date"]
             });
 
-            assert.same(clearTimeout, lolex.timers.clearTimeout);
-            assert.same(setInterval, lolex.timers.setInterval);
-            assert.same(clearInterval, lolex.timers.clearInterval);
+            assert.same(clearTimeout, FakeTimers.timers.clearTimeout);
+            assert.same(setInterval, FakeTimers.timers.setInterval);
+            assert.same(clearInterval, FakeTimers.timers.clearInterval);
         });
     });
 
@@ -3777,7 +3780,10 @@ describe("lolex", function() {
         it("should create an auto advancing timer", function(done) {
             var testDelay = 29;
             var date = new Date("2015-09-25");
-            var clock = lolex.install({ now: date, shouldAdvanceTime: true });
+            var clock = FakeTimers.install({
+                now: date,
+                shouldAdvanceTime: true
+            });
             assert.same(Date.now(), 1443139200000);
             var timeoutStarted = Date.now();
 
@@ -3795,7 +3801,10 @@ describe("lolex", function() {
             }
 
             var date = new Date("2015-09-25");
-            var clock = lolex.install({ now: date, shouldAdvanceTime: true });
+            var clock = FakeTimers.install({
+                now: date,
+                shouldAdvanceTime: true
+            });
             assert.same(Date.now(), 1443139200000);
             var timeoutStarted = Date.now();
 
@@ -3812,7 +3821,10 @@ describe("lolex", function() {
             var intervalsTriggered = 0;
             var cyclesToTrigger = 3;
             var date = new Date("2015-09-25");
-            var clock = lolex.install({ now: date, shouldAdvanceTime: true });
+            var clock = FakeTimers.install({
+                now: date,
+                shouldAdvanceTime: true
+            });
             assert.same(Date.now(), 1443139200000);
             var timeoutStarted = Date.now();
 
@@ -3830,7 +3842,7 @@ describe("lolex", function() {
 
     describe("requestAnimationFrame", function() {
         beforeEach(function() {
-            this.clock = lolex.createClock();
+            this.clock = FakeTimers.createClock();
         });
 
         it("throws if no arguments", function() {
@@ -3926,7 +3938,7 @@ describe("lolex", function() {
 
     describe("cancelAnimationFrame", function() {
         beforeEach(function() {
-            this.clock = lolex.createClock();
+            this.clock = FakeTimers.createClock();
         });
 
         it("removes animation frame", function() {
@@ -4001,7 +4013,7 @@ describe("lolex", function() {
 
     describe("runToFrame", function() {
         beforeEach(function() {
-            this.clock = lolex.createClock();
+            this.clock = FakeTimers.createClock();
         });
 
         it("should tick next frame", function() {
@@ -4024,20 +4036,20 @@ describe("lolex", function() {
         });
 
         it("should start at 0", function() {
-            var clock = lolex.createClock(1001);
+            var clock = FakeTimers.createClock(1001);
             var result = clock.performance.now();
             assert.same(result, 0);
         });
 
         it("should run along with clock.tick", function() {
-            var clock = lolex.createClock(0);
+            var clock = FakeTimers.createClock(0);
             clock.tick(5001);
             var result = clock.performance.now();
             assert.same(result, 5001);
         });
 
         it("should listen to multiple ticks in performance.now", function() {
-            var clock = lolex.createClock(0);
+            var clock = FakeTimers.createClock(0);
             for (var i = 0; i < 10; i++) {
                 var next = clock.performance.now();
                 assert.same(next, 1000 * i);
@@ -4046,7 +4058,7 @@ describe("lolex", function() {
         });
 
         it("should run with ticks with timers set", function() {
-            var clock = lolex.createClock(0);
+            var clock = FakeTimers.createClock(0);
             clock.setTimeout(function() {
                 var result = clock.performance.now();
                 assert.same(result, 2500);
@@ -4069,14 +4081,14 @@ describe("lolex", function() {
         });
 
         it("should start at 0", function() {
-            var clock = lolex.createClock(1001);
+            var clock = FakeTimers.createClock(1001);
             var result = clock.hrtime();
             assert.same(result[0], 0);
             assert.same(result[1], 0);
         });
 
         it("should run along with clock.tick", function() {
-            var clock = lolex.createClock(0);
+            var clock = FakeTimers.createClock(0);
             clock.tick(5001);
             var prev = clock.hrtime();
             clock.tick(5001);
@@ -4086,7 +4098,7 @@ describe("lolex", function() {
         });
 
         it("should run along with clock.tick when timers set", function() {
-            var clock = lolex.createClock(0);
+            var clock = FakeTimers.createClock(0);
             var prev = clock.hrtime();
             clock.setTimeout(function() {
                 var result = clock.hrtime(prev);
@@ -4097,7 +4109,7 @@ describe("lolex", function() {
         });
 
         it("should not move with setSystemTime", function() {
-            var clock = lolex.createClock(0);
+            var clock = FakeTimers.createClock(0);
             var prev = clock.hrtime();
             clock.setSystemTime(9000);
             clock.setSystemTime(50000);
@@ -4107,7 +4119,7 @@ describe("lolex", function() {
         });
 
         it("should move with timeouts", function() {
-            var clock = lolex.createClock();
+            var clock = FakeTimers.createClock();
             var result = clock.hrtime();
             assert.same(result[0], 0);
             assert.same(result[1], 0);
@@ -4119,7 +4131,7 @@ describe("lolex", function() {
         });
 
         it("should handle floating point", function() {
-            var clock = lolex.createClock();
+            var clock = FakeTimers.createClock();
             clock.tick(1022.7791);
             var result = clock.hrtime([0, 20000000]);
 
@@ -4141,20 +4153,20 @@ describe("lolex", function() {
         });
 
         it("should start at 0n", function() {
-            var clock = lolex.createClock(1001);
+            var clock = FakeTimers.createClock(1001);
             var result = clock.hrtime.bigint();
             assert.same(result, BigInt(0)); // eslint-disable-line
         });
 
         it("should run along with clock.tick", function() {
-            var clock = lolex.createClock(0);
+            var clock = FakeTimers.createClock(0);
             clock.tick(5001);
             var result = clock.hrtime.bigint();
             assert.same(result, BigInt(5.001e9)); // eslint-disable-line
         });
 
         it("should run along with clock.tick when timers set", function() {
-            var clock = lolex.createClock(0);
+            var clock = FakeTimers.createClock(0);
             clock.setTimeout(function() {
                 var result = clock.hrtime.bigint();
                 assert.same(result, BigInt(2.5e9)); // eslint-disable-line
@@ -4163,14 +4175,14 @@ describe("lolex", function() {
         });
 
         it("should not move with setSystemTime", function() {
-            var clock = lolex.createClock(0);
+            var clock = FakeTimers.createClock(0);
             clock.setSystemTime(50000);
             var result = clock.hrtime.bigint();
             assert.same(result, BigInt(0)); // eslint-disable-line
         });
 
         it("should move with timeouts", function() {
-            var clock = lolex.createClock();
+            var clock = FakeTimers.createClock();
             var result = clock.hrtime.bigint();
             assert.same(result, BigInt(0)); // eslint-disable-line
             clock.setTimeout(function() {}, 1000);
@@ -4189,7 +4201,7 @@ describe("lolex", function() {
             }
         });
         beforeEach(function() {
-            clock = lolex.createClock();
+            clock = FakeTimers.createClock();
             called = false;
         });
         it("runs without timers", function() {
@@ -4229,7 +4241,7 @@ describe("lolex", function() {
         });
 
         it("runs without timers", function() {
-            var clock = lolex.createClock();
+            var clock = FakeTimers.createClock();
             var called = false;
             clock.nextTick(function() {
                 called = true;
@@ -4239,7 +4251,7 @@ describe("lolex", function() {
         });
 
         it("runs when runMicrotasks is called on the clock", function() {
-            var clock = lolex.createClock();
+            var clock = FakeTimers.createClock();
             var called = false;
             clock.nextTick(function() {
                 called = true;
@@ -4249,7 +4261,7 @@ describe("lolex", function() {
         });
 
         it("respects loopLimit from below in runMicrotasks", function() {
-            var clock = lolex.createClock(0, 100);
+            var clock = FakeTimers.createClock(0, 100);
             var i;
 
             for (i = 0; i < 99; i++) {
@@ -4263,7 +4275,7 @@ describe("lolex", function() {
         });
 
         it("respects loopLimit from above in runMicrotasks", function() {
-            var clock = lolex.createClock(0, 100);
+            var clock = FakeTimers.createClock(0, 100);
             for (var i = 0; i < 120; i++) {
                 // eslint-disable-next-line ie11/no-loop-func
                 clock.nextTick(function() {});
@@ -4274,7 +4286,7 @@ describe("lolex", function() {
         });
 
         it("detects infinite nextTick cycles", function() {
-            var clock = lolex.createClock(0, 1000);
+            var clock = FakeTimers.createClock(0, 1000);
             clock.nextTick(function repeat() {
                 clock.nextTick(repeat);
             });
@@ -4284,7 +4296,7 @@ describe("lolex", function() {
         });
 
         it("runs with timers - and before them", function() {
-            var clock = lolex.createClock();
+            var clock = FakeTimers.createClock();
             var last = "";
             var called = false;
             clock.nextTick(function() {
@@ -4300,7 +4312,7 @@ describe("lolex", function() {
         });
 
         it("runs when time is progressed", function() {
-            var clock = lolex.createClock();
+            var clock = FakeTimers.createClock();
             var called = false;
             clock.nextTick(function() {
                 called = true;
@@ -4311,7 +4323,7 @@ describe("lolex", function() {
         });
 
         it("runs between timers", function() {
-            var clock = lolex.createClock();
+            var clock = FakeTimers.createClock();
             var order = [];
             clock.setTimeout(function() {
                 order.push("timer-1");
@@ -4330,7 +4342,7 @@ describe("lolex", function() {
         });
 
         it("installs with microticks", function() {
-            var clock = lolex.install({ toFake: ["nextTick"] });
+            var clock = FakeTimers.install({ toFake: ["nextTick"] });
             var called = false;
             process.nextTick(function() {
                 called = true;
@@ -4341,7 +4353,9 @@ describe("lolex", function() {
         });
 
         it("installs with microticks and timers in order", function() {
-            var clock = lolex.install({ toFake: ["nextTick", "setTimeout"] });
+            var clock = FakeTimers.install({
+                toFake: ["nextTick", "setTimeout"]
+            });
             var order = [];
             setTimeout(function() {
                 order.push("timer-1");
@@ -4360,7 +4374,7 @@ describe("lolex", function() {
         });
 
         it("uninstalls", function() {
-            var clock = lolex.install({ toFake: ["nextTick"] });
+            var clock = FakeTimers.install({ toFake: ["nextTick"] });
             clock.uninstall();
             var called = false;
             process.nextTick(function() {
@@ -4371,13 +4385,13 @@ describe("lolex", function() {
         });
 
         it("returns an empty list of timers on immediate uninstall", function() {
-            var clock = lolex.install();
+            var clock = FakeTimers.install();
             var timers = clock.uninstall();
             assert.equals(timers, []);
         });
 
         it("returns a timer if uninstalling before it's called", function() {
-            var clock = lolex.install();
+            var clock = FakeTimers.install();
             clock.setTimeout(function() {}, 100);
             var timers = clock.uninstall();
             assert.equals(timers.length, 1);
@@ -4387,7 +4401,7 @@ describe("lolex", function() {
         });
 
         it("does not return already executed timers on uninstall", function() {
-            var clock = lolex.install();
+            var clock = FakeTimers.install();
             clock.setTimeout(function() {}, 100);
             clock.setTimeout(function() {}, 200);
             clock.tick(100);
@@ -4399,7 +4413,7 @@ describe("lolex", function() {
         });
 
         it("returns multiple timers on uninstall if created", function() {
-            var clock = lolex.install();
+            var clock = FakeTimers.install();
             var i;
 
             for (i = 0; i < 5; i++) {
@@ -4417,7 +4431,7 @@ describe("lolex", function() {
         });
 
         it("passes arguments when installed - GitHub#122", function() {
-            var clock = lolex.install({ toFake: ["nextTick"] });
+            var clock = FakeTimers.install({ toFake: ["nextTick"] });
             var called = false;
             process.nextTick(function(value) {
                 called = value;
@@ -4428,7 +4442,7 @@ describe("lolex", function() {
         });
 
         it("does not install by default - GitHub#126", function(done) {
-            var clock = lolex.install();
+            var clock = FakeTimers.install();
             var spy = sinon.spy(clock, "nextTick");
             var called = false;
             process.nextTick(function(value) {
@@ -4443,7 +4457,7 @@ describe("lolex", function() {
 
     describe("requestIdleCallback", function() {
         beforeEach(function() {
-            this.clock = lolex.createClock();
+            this.clock = FakeTimers.createClock();
         });
 
         it("throws if no arguments", function() {
@@ -4506,7 +4520,7 @@ describe("lolex", function() {
 
     describe("cancelIdleCallback", function() {
         beforeEach(function() {
-            this.clock = lolex.createClock();
+            this.clock = FakeTimers.createClock();
         });
 
         it("removes idle callback", function() {


### PR DESCRIPTION
This PR renames the package to `@sinonjs/fake-clock`.

#### Purpose

It was suggested that we rename this package to have a less confusing name (I can't recall who suggested it, or in which communication channel).

I will soon be doing a larger effort in improving the documentation of Sinon and associated libraries. I thought it would be beneficial to that effort to get the rename of packages out of the way first.

See https://github.com/sinonjs/sinon/issues/1651

#### Plan

1. Rename repository
1. Merge this branch
1. Bump the major version
1. Publish the renamed package to `npm` registry
1. Deprecate the `lolex` package in the `npm` registry
1. Update `sinon` to use the new package

#### How to verify

1. Check out this branch
1. (this repo): `npm ci`
1. (this repo): `npm link`
1. (sinon repo): `npm link @sinonjs/fake-clock`
1. (sinon repo): Update the `lib/sinon/util/fake-timers.js` to use `@sinonjs/fake-clock` instead of `lolex`
1. (sinon repo): `npm test`
1. Observe tests pass