### PR TITLE
Fix failing tests in IE11

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -1197,6 +1197,19 @@ function withGlobal(_global) {
      */
     // eslint-disable-next-line complexity
     function install(config) {
+        if (
+            arguments.length > 1 ||
+            config instanceof Date ||
+            Array.isArray(config) ||
+            typeof config === "number"
+        ) {
+            throw new TypeError(
+                "FakeTimers.install called with " +
+                    String(config) +
+                    " install requires an object parameter"
+            );
+        }
+
         // eslint-disable-next-line no-param-reassign
         config = typeof config !== "undefined" ? config : {};
         config.shouldAdvanceTime = config.shouldAdvanceTime || false;


### PR DESCRIPTION
When running `npm run test-cloud`, the tests would fail in IE11.

In 4cdc47d8e0876ca38d0497e8f358ef9e4a643bf7 the code inserted here was
removed, as it was thought to not be necessary. For whatever reason,
this code is depended on for the tests to be set up correctly in IE11.

Putting the code back fixes the tests.

#### How to verify

1. Check out this branch
1. `npm ci`
1. `npm run test-cloud`
1. Observe that tests pass in all browsers tested