### PR TITLE
Remove config.target

### DIFF
--- a/integration-test/fake-clock-integration-test.js
+++ b/integration-test/fake-clock-integration-test.js
@@ -37,7 +37,7 @@ describe("withGlobal", function() {
     });
 
     it("should support basic setTimeout", function() {
-        var clock = withGlobal.install({ target: jsdomGlobal, toFake: timers });
+        var clock = withGlobal.install({ toFake: timers });
         var stub = sinon.stub();
 
         jsdomGlobal.setTimeout(stub, 5);
@@ -50,7 +50,7 @@ describe("withGlobal", function() {
     it("Date is instanceof itself", function() {
         assert(new jsdomGlobal.Date() instanceof jsdomGlobal.Date);
 
-        var clock = withGlobal.install({ target: jsdomGlobal, toFake: timers });
+        var clock = withGlobal.install({ toFake: timers });
 
         assert(new jsdomGlobal.Date() instanceof jsdomGlobal.Date);
 
@@ -78,9 +78,7 @@ describe("globally configured browser objects", function() {
 
         global.window = window;
         global.document = window.document;
-        global.navigator = {
-            userAgent: "node.js"
-        };
+        global.navigator = window.navigator;
         global.requestAnimationFrame = function(callback) {
             return setTimeout(callback, 0);
         };

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,9 +140,9 @@
       }
     },
     "@sinonjs/commons": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.0.tgz",
-      "integrity": "sha512-qbk9AP+cZUsKdW1GJsBpxPKFmCJ0T8swwzVje3qFd+AkQb74Q/tiuzrdfFg8AD2g5HH/XbE/I8Uc1KYHVYWfhg==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
+      "integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
       "requires": {
         "type-detect": "4.0.8"
       }

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -4593,3 +4593,11 @@ describe("FakeTimers", function() {
         });
     });
 });
+
+describe("#276 - remove config.target", function() {
+    it("should throw on using `config.target`", function() {
+        assert.exception(function() {
+            FakeTimers.install({ target: {} });
+        }, /config.target is no longer supported/);
+    });
+});

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -53,15 +53,19 @@ var setImmediatePresent =
 var utilPromisify = global.process && require("util").promisify;
 
 describe("issue #59", function() {
+    var setTimeoutFake = sinon.fake();
     var context = {
         Date: Date,
-        setTimeout: setTimeout,
-        clearTimeout: clearTimeout
+        setTimeout: setTimeoutFake,
+        clearTimeout: sinon.fake()
     };
     var clock;
 
     it("should install and uninstall the clock on a custom target", function() {
-        clock = FakeTimers.install(context);
+        clock = FakeTimers.withGlobal(context).install();
+        assert.equals(setTimeoutFake.callCount, 1);
+        clock.setTimeout(NOOP, 0);
+        assert.equals(setTimeoutFake.callCount, 1);
         // this would throw an error before issue #59 was fixed
         clock.uninstall();
     });


### PR DESCRIPTION
Removes `config.target`, simplifying the API by
only making it possible to choose alternate targets
using `withGlobal(target)`.

See discussion in #276 and sinonjs/sinon#2156