### PR TITLE
Convert timer delay to number if not already

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -271,7 +271,7 @@ function withGlobal(_global) {
 
         if (timer.hasOwnProperty("delay")) {
             if (typeof timer.delay !== "number") {
-              timer.delay = praseInt(timer.delay, 10);
+                timer.delay = parseInt(timer.delay, 10);
             }
 
             if (!isNumberFinite(timer.delay)) {

--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -270,7 +270,7 @@ function withGlobal(_global) {
         timer.type = timer.immediate ? "Immediate" : "Timeout";
 
         if (timer.hasOwnProperty("delay")) {
-            if (typeof timer.delay !== 'number') {
+            if (typeof timer.delay !== "number") {
               timer.delay = praseInt(timer.delay, 10);
             }
 

--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -72,10 +72,6 @@ function withGlobal(_global) {
             return Number.isFinite(num);
         }
 
-        if (typeof num !== "number") {
-            return false;
-        }
-
         return isFinite(num);
     }
 
@@ -274,6 +270,10 @@ function withGlobal(_global) {
         timer.type = timer.immediate ? "Immediate" : "Timeout";
 
         if (timer.hasOwnProperty("delay")) {
+            if (typeof timer.delay !== 'number') {
+              timer.delay = praseInt(timer.delay, 10);
+            }
+
             if (!isNumberFinite(timer.delay)) {
                 timer.delay = 0;
             }

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -4605,3 +4605,16 @@ describe("#276 - remove config.target", function() {
         }, /config.target is no longer supported/);
     });
 });
+
+describe("issue #315 - praseInt if delay not a number", function() {
+    it("should successfully execute the timer", function() {
+        var clock = FakeTimers.install();
+        var stub1 = sinon.stub();
+
+        clock.setTimeout(stub1, "1");
+        clock.tick(1);
+        assert(stub1.calledOnce);
+
+        clock.uninstall();
+    });
+});

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -4606,7 +4606,7 @@ describe("#276 - remove config.target", function() {
     });
 });
 
-describe("issue #315 - praseInt if delay not a number", function() {
+describe("issue #315 - praseInt if delay is not a number", function() {
     it("should successfully execute the timer", function() {
         var clock = FakeTimers.install();
         var stub1 = sinon.stub();


### PR DESCRIPTION
#### Purpose
Fix issue #315 by checking if `timer.delay` is a number. If it isn't make it one by parsing it to an integer.
