### PR TITLE
issue #304 fix

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -444,7 +444,11 @@ function withGlobal(_global) {
         if (clock.timers.hasOwnProperty(id)) {
             // check that the ID matches a timer of the correct type
             var timer = clock.timers[id];
-            if (timer.type === ttype) {
+            if (
+                timer.type === ttype ||
+                (timer.type === "Timeout" && ttype === "Interval") ||
+                (timer.type === "Interval" && ttype === "Timeout")
+            ) {
                 delete clock.timers[id];
             } else {
                 var clear =

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -2989,38 +2989,22 @@ describe("FakeTimers", function() {
             assert.isFalse(stub.called);
         });
 
-        it("does not remove interval", function() {
+        it("removes interval", function() {
             var stub = sinon.stub();
             var id = this.clock.setInterval(stub, 50);
-            assert.exception(
-                function() {
-                    this.clock.clearTimeout(id);
-                }.bind(this),
-                {
-                    message:
-                        "Cannot clear timer: timer created with setInterval() but cleared with clearTimeout()"
-                }
-            );
+            this.clock.clearTimeout(id);
             this.clock.tick(50);
 
-            assert.isTrue(stub.called);
+            assert.isFalse(stub.called);
         });
 
-        it("does not remove interval with undefined interval", function() {
+        it("removes interval with undefined interval", function() {
             var stub = sinon.stub();
             var id = this.clock.setInterval(stub);
-            assert.exception(
-                function() {
-                    this.clock.clearTimeout(id);
-                }.bind(this),
-                {
-                    message:
-                        "Cannot clear timer: timer created with setInterval() but cleared with clearTimeout()"
-                }
-            );
+            this.clock.clearTimeout(id);
             this.clock.tick(50);
 
-            assert.isTrue(stub.called);
+            assert.isFalse(stub.called);
         });
 
         it("does not remove immediate", function() {
@@ -3198,20 +3182,13 @@ describe("FakeTimers", function() {
             assert.isFalse(stub.called);
         });
 
-        it("does not remove timeout", function() {
+        it("removes timeout", function() {
             var stub = sinon.stub();
             var id = this.clock.setTimeout(stub, 50);
-            assert.exception(
-                function() {
-                    this.clock.clearInterval(id);
-                }.bind(this),
-                {
-                    message:
-                        "Cannot clear timer: timer created with setTimeout() but cleared with clearInterval()"
-                }
-            );
+            this.clock.clearInterval(id);
             this.clock.tick(50);
-            assert.isTrue(stub.called);
+
+            assert.isFalse(stub.called);
         });
 
         it("does not remove immediate", function() {


### PR DESCRIPTION
#### Purpose 
Allowing `clearTimeout` to clear `setInterval` and `clearInterval` to clear `setTimeout`, 
as this is possible by HTML Living Standard.
Issue #304  
Tests were altered to match the new changes :)
