### PR TITLE
Add stack trace to code recursively scheduling timers

### DIFF
--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -4805,7 +4805,7 @@ describe("loop limit stack trace", function() {
     describe("setInterval", function() {
         beforeEach(function() {
             function recursiveCreateTimer() {
-                test.clock.setInterval(function recursiveCreateTimerTimeout() {
+                setInterval(function recursiveCreateTimerTimeout() {
                     recursiveCreateTimer();
                 }, 10);
             }
@@ -4861,9 +4861,9 @@ describe("loop limit stack trace", function() {
             }
 
             function recursiveCreateTimer() {
-                test.clock.setImmediate(function recursiveCreateTimerTimeout() {
+                setImmediate(function recursiveCreateTimerTimeout() {
                     recursiveCreateTimer();
-                }, 10);
+                });
             }
             recursiveCreateTimer();
         });
@@ -4916,8 +4916,7 @@ describe("loop limit stack trace", function() {
                 test.clock.requestAnimationFrame(
                     function recursiveCreateTimerTimeout() {
                         recursiveCreateTimer();
-                    },
-                    10
+                    }
                 );
             }
             recursiveCreateTimer();


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
<!--
> give a concise (one or two short sentences) description of what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->
Fix issue #230 by using stack information for jobs and timers to provide more context when an infinite loop error is thrown.

<!--
#### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->



#### Solution  - optional

<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

This solution works by adding a `stack` property to jobs and tasks. This data can then be used, if an infinite loop is detected, to set the stack of the thrown `infiniteLoopError`.


##### Example stack trace from test run
```
Error: Aborting after running 5 timers, assuming an infinite loop!
Timeout - recursiveCreateTimerTimeout
      at recursiveCreateTimer (test/fake-timers-test.js:4668)
      at recursiveCreateTimerTimeout (test/fake-timers-test.js:4669)
      at callTimer (src/fake-timers-src.js:441)
      at Object.next (src/fake-timers-src.js:1039)
      at src/fake-timers-src.js:1128
```