### PR TITLE
Remove use of `eval`

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -421,8 +421,12 @@ function withGlobal(_global) {
         if (typeof timer.func === "function") {
             timer.func.apply(null, timer.args);
         } else {
-            /* eslint no-eval: "off" */
-            eval(timer.func);
+            throw new Error(
+                "TypeError [ERR_INVALID_CALLBACK]: Callback must be a function. Received " +
+                    timer.func +
+                    " of type " +
+                    typeof timer.func
+            );
         }
     }
 

--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -421,8 +421,8 @@ function withGlobal(_global) {
         if (typeof timer.func === "function") {
             timer.func.apply(null, timer.args);
         } else {
-            throw new Error(
-                "TypeError [ERR_INVALID_CALLBACK]: Callback must be a function. Received " +
+            throw new TypeError(
+                "[ERR_INVALID_CALLBACK]: Callback must be a function. Received " +
                     timer.func +
                     " of type " +
                     typeof timer.func

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -330,7 +330,7 @@ describe("FakeTimers", function() {
                 }.bind(this),
                 {
                     message:
-                        "TypeError [ERR_INVALID_CALLBACK]: Callback must be a function. Received " +
+                        "[ERR_INVALID_CALLBACK]: Callback must be a function. Received " +
                         notTypeofFunction +
                         " of type " +
                         typeof notTypeofFunction

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -320,11 +320,22 @@ describe("FakeTimers", function() {
             assert(FakeTimers.evalCalled);
         });
 
-        it("evals non-function callbacks", function() {
-            this.clock.setTimeout("FakeTimers.evalCalled = true", 10);
-            this.clock.tick(10);
+        it("does not accept non-function callbacks", function() {
+            var notTypeofFunction = "FakeTimers.evalCalled = true";
+            this.clock.setTimeout(notTypeofFunction, 10);
 
-            assert(FakeTimers.evalCalled);
+            assert.exception(
+                function() {
+                    this.clock.tick(10);
+                }.bind(this),
+                {
+                    message:
+                        "TypeError [ERR_INVALID_CALLBACK]: Callback must be a function. Received " +
+                        notTypeofFunction +
+                        " of type " +
+                        typeof notTypeofFunction
+                }
+            );
         });
 
         it("passes setTimeout parameters", function() {


### PR DESCRIPTION
#### Purpose 
Removing the use of `eval()` as there are 'Rollup complaints about the use of eval.'
According to MDN: 

> 'Executing JavaScript from a string is an enormous security risk'

Issue #319 