### PR TITLE
Support timeout.refresh in node environments

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -312,7 +312,8 @@ function withGlobal(_global) {
                     return res;
                 },
                 refresh: function() {
-                    return res;
+                    clearTimeout(timer.id);
+                    return setTimeout(timer.func, timer.delay);
                 }
             };
             return res;

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -4595,3 +4595,30 @@ describe("issue #315 - praseInt if delay is not a number", function() {
         clock.uninstall();
     });
 });
+
+describe("#187 - Support timeout.refresh in node environments", function() {
+    it("calls the stub again after refreshing the timeout", function() {
+        var clock = FakeTimers.install();
+        var stub = sinon.stub();
+
+        if (typeof setTimeout(NOOP, 0) === "object") {
+            var t = setTimeout(stub, 1000);
+            clock.tick(1000);
+            t.refresh();
+            clock.tick(1000);
+            assert(stub.calledTwice);
+        }
+        clock.uninstall();
+    });
+
+    it("assigns a new id to the refreshed timer", function() {
+        var clock = FakeTimers.install();
+        var stub = sinon.stub();
+        if (typeof setTimeout(NOOP, 0) === "object") {
+            var t = setTimeout(stub, 1000);
+            var t2 = t.refresh();
+            refute.same(t.id, t2.id);
+        }
+        clock.uninstall();
+    });
+});


### PR DESCRIPTION
#### Purpose
Fix issue #187 by adding an actual implementation to `refresh()`.

#### Background
Previously, `refresh()` was added to the timer API as an alternative to manually resetting timeouts via `clearTimeout()` and `setTimeout()`. However, while the interface itself was added, it remained a no-op function. This is confusing, since the presence of this function creates the expectation that the timer has been refreshed when it actually hasn't.

#### Solution 
`refresh()` now clears the existing timeout and generates a new one with the same function and delay parameters, but a new ID.