### PR TITLE
issue #304 second fix - clearTimeout clears setInterval and clearInterval clears setTimeout

### DIFF
--- a/fake-timers.js
+++ b/fake-timers.js
@@ -1751,7 +1751,10 @@ function withGlobal(_global) {
         if (clock.timers.hasOwnProperty(id)) {
             // check that the ID matches a timer of the correct type
             var timer = clock.timers[id];
-            if (timer.type === ttype) {
+            if (timer.type === ttype ||
+                (timer.type === "Timeout" && ttype === "Interval") ||
+                (timer.type === "Interval" && ttype === "Timeout")
+            ) {
                 delete clock.timers[id];
             } else {
                 var clear =


### PR DESCRIPTION
## Purpose
This is a follow up to pull request #324 

> Allowing clearTimeout to clear setInterval and clearInterval to clear setTimeout,
as this is possible by HTML Living Standard.
Issue #304

After starting a simple Rollup project and using this package locally through `npm-link`  I found out that the problem wasn't solved..

Apparently, only one file is being tested and the same function [`clearTimer()`] exists in two different files. Therefore, I found out that only changing `fake-timers-src.js` was not enough to actually make the change, but only to pass the test. It seems that `fake-timers.js` isn't being tested.

For further info read: https://github.com/sinonjs/fake-timers/issues/304#issuecomment-629370417 and also https://github.com/sinonjs/fake-timers/issues/304#issuecomment-629640406

**Oh, and one more thing**: The file `fake-timers.js` changes entirely (as opposed to `fake-timers-src.js`) when you click save in `VSCode`, probably because of the auto-indent option. Could anyone please check it for me? I just opened it on an old sublime to not change gazillion lines :)