### PR TITLE
Removing the use of eval in Node.js

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -278,6 +278,17 @@ function withGlobal(_global) {
                 );
             }
         }
+        if (addTimerReturnsObject) {
+            // Node.js environment
+            if (typeof timer.func !== "function") {
+                throw new TypeError(
+                    "[ERR_INVALID_CALLBACK]: Callback must be a function. Received " +
+                        timer.func +
+                        " of type " +
+                        typeof timer.func
+                );
+            }
+        }
 
         timer.type = timer.immediate ? "Immediate" : "Timeout";
 

--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -267,6 +267,18 @@ function withGlobal(_global) {
             throw new Error("Callback must be provided to timer calls");
         }
 
+        if (addTimerReturnsObject) {
+            // Node.js environment
+            if (typeof timer.func !== "function") {
+                throw new TypeError(
+                    "[ERR_INVALID_CALLBACK]: Callback must be a function. Received " +
+                        timer.func +
+                        " of type " +
+                        typeof timer.func
+                );
+            }
+        }
+
         timer.type = timer.immediate ? "Immediate" : "Timeout";
 
         if (timer.hasOwnProperty("delay")) {

--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -278,17 +278,6 @@ function withGlobal(_global) {
                 );
             }
         }
-        if (addTimerReturnsObject) {
-            // Node.js environment
-            if (typeof timer.func !== "function") {
-                throw new TypeError(
-                    "[ERR_INVALID_CALLBACK]: Callback must be a function. Received " +
-                        timer.func +
-                        " of type " +
-                        typeof timer.func
-                );
-            }
-        }
 
         timer.type = timer.immediate ? "Immediate" : "Timeout";
 

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -51,6 +51,8 @@ var performanceMarkPresent =
 var setImmediatePresent =
     global.setImmediate && typeof global.setImmediate === "function";
 var utilPromisify = global.process && require("util").promisify;
+var timeoutResult = global.setTimeout(NOOP, 0);
+var addTimerReturnsObject = typeof timeoutResult === "object";
 
 describe("issue #59", function () {
     var setTimeoutFake = sinon.fake();
@@ -272,13 +274,8 @@ describe("FakeTimers", function () {
             });
         });
 
-<<<<<<< HEAD
-        it("returns numeric id or object with numeric id", function () {
-            var result = this.clock.setTimeout("");
-=======
         it("returns numeric id or object with numeric id", function() {
             var result = this.clock.setTimeout(function() {}, 10);
->>>>>>> strings were replaced from tests who do not require eval
 
             if (typeof result === "object") {
                 assert.isNumber(result.id);
@@ -287,15 +284,9 @@ describe("FakeTimers", function () {
             }
         });
 
-<<<<<<< HEAD
-        it("returns unique id", function () {
-            var id1 = this.clock.setTimeout("");
-            var id2 = this.clock.setTimeout("");
-=======
         it("returns unique id", function() {
             var id1 = this.clock.setTimeout(function() {}, 10);
             var id2 = this.clock.setTimeout(function() {}, 10);
->>>>>>> strings were replaced from tests who do not require eval
 
             refute.equals(id2, id1);
         });
@@ -331,25 +322,7 @@ describe("FakeTimers", function () {
             assert(FakeTimers.evalCalled);
         });
 
-        it("evals non-function callbacks", function () {
-            this.clock.setTimeout("FakeTimers.evalCalled = true", 10);
-            this.clock.tick(10);
-
-            assert(FakeTimers.evalCalled);
-        });
-
-        it("only evals on global scope", function () {
-            var x = 15;
-            try {
-                this.clock.setTimeout("x", x);
-                this.clock.tick(x);
-                assert.fail();
-            } catch (e) {
-                assert(e instanceof ReferenceError);
-            }
-        });
-
-        it("passes setTimeout parameters", function () {
+        it("passes setTimeout parameters", function() {
             var clock = FakeTimers.createClock();
             var stub = sinon.stub();
 
@@ -471,6 +444,74 @@ describe("FakeTimers", function () {
             }, Number.NEGATIVE_INFINITY);
             this.clock.runAll();
             assert.equals(calls, ["NaN", "Infinity", "-Infinity"]);
+        });
+
+        describe("use of eval when not in node", function() {
+            before(function() {
+                if (addTimerReturnsObject) {
+                    this.skip();
+                }
+            });
+
+            beforeEach(function() {
+                this.clock = FakeTimers.createClock();
+                FakeTimers.evalCalled = false;
+            });
+
+            afterEach(function() {
+                delete FakeTimers.evalCalled;
+            });
+
+            it("evals non-function callbacks", function() {
+                this.clock.setTimeout("FakeTimers.evalCalled = true", 10);
+                this.clock.tick(10);
+
+                assert(FakeTimers.evalCalled);
+            });
+
+            it("only evals on global scope", function() {
+                var x = 15;
+                try {
+                    this.clock.setTimeout("x", x);
+                    this.clock.tick(x);
+                    assert.fail();
+                } catch (e) {
+                    assert(e instanceof ReferenceError);
+                }
+            });
+        });
+        describe("use of eval in node", function() {
+            before(function() {
+                if (!addTimerReturnsObject) {
+                    this.skip();
+                }
+            });
+
+            beforeEach(function() {
+                this.clock = FakeTimers.createClock();
+                FakeTimers.evalCalled = false;
+            });
+
+            afterEach(function() {
+                delete FakeTimers.evalCalled;
+            });
+
+            it("does not eval non-function callbacks", function() {
+                var notTypeofFunction = "FakeTimers.evalCalled = true";
+
+                assert.exception(
+                    function() {
+                        this.clock.setTimeout(notTypeofFunction, 10);
+                    }.bind(this),
+                    {
+                        message:
+                            "[ERR_INVALID_CALLBACK]: Callback must be a function. Received " +
+                            notTypeofFunction +
+                            " of type " +
+                            typeof notTypeofFunction
+                    }
+                );
+            });
         });
 
         if (typeof global.Promise !== "undefined" && utilPromisify) {
@@ -3102,13 +3143,8 @@ describe("FakeTimers", function () {
             });
         });
 
-<<<<<<< HEAD
-        it("returns numeric id or object with numeric id", function () {
-            var result = this.clock.setInterval("");
-=======
         it("returns numeric id or object with numeric id", function() {
             var result = this.clock.setInterval(function() {}, 10);
->>>>>>> strings were replaced from tests who do not require eval
 
             if (typeof result === "object") {
                 assert.isNumber(result.id);
@@ -3117,15 +3153,9 @@ describe("FakeTimers", function () {
             }
         });
 
-<<<<<<< HEAD
-        it("returns unique id", function () {
-            var id1 = this.clock.setInterval("");
-            var id2 = this.clock.setInterval("");
-=======
         it("returns unique id", function() {
             var id1 = this.clock.setInterval(function() {}, 10);
             var id2 = this.clock.setInterval(function() {}, 10);
->>>>>>> strings were replaced from tests who do not require eval
 
             refute.equals(id2, id1);
         });

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -272,8 +272,13 @@ describe("FakeTimers", function () {
             });
         });
 
+<<<<<<< HEAD
         it("returns numeric id or object with numeric id", function () {
             var result = this.clock.setTimeout("");
+=======
+        it("returns numeric id or object with numeric id", function() {
+            var result = this.clock.setTimeout(function() {}, 10);
+>>>>>>> strings were replaced from tests who do not require eval
 
             if (typeof result === "object") {
                 assert.isNumber(result.id);
@@ -282,9 +287,15 @@ describe("FakeTimers", function () {
             }
         });
 
+<<<<<<< HEAD
         it("returns unique id", function () {
             var id1 = this.clock.setTimeout("");
             var id2 = this.clock.setTimeout("");
+=======
+        it("returns unique id", function() {
+            var id1 = this.clock.setTimeout(function() {}, 10);
+            var id2 = this.clock.setTimeout(function() {}, 10);
+>>>>>>> strings were replaced from tests who do not require eval
 
             refute.equals(id2, id1);
         });
@@ -3091,8 +3102,13 @@ describe("FakeTimers", function () {
             });
         });
 
+<<<<<<< HEAD
         it("returns numeric id or object with numeric id", function () {
             var result = this.clock.setInterval("");
+=======
+        it("returns numeric id or object with numeric id", function() {
+            var result = this.clock.setInterval(function() {}, 10);
+>>>>>>> strings were replaced from tests who do not require eval
 
             if (typeof result === "object") {
                 assert.isNumber(result.id);
@@ -3101,9 +3117,15 @@ describe("FakeTimers", function () {
             }
         });
 
+<<<<<<< HEAD
         it("returns unique id", function () {
             var id1 = this.clock.setInterval("");
             var id2 = this.clock.setInterval("");
+=======
+        it("returns unique id", function() {
+            var id1 = this.clock.setInterval(function() {}, 10);
+            var id2 = this.clock.setInterval(function() {}, 10);
+>>>>>>> strings were replaced from tests who do not require eval
 
             refute.equals(id2, id1);
         });

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -322,25 +322,6 @@ describe("FakeTimers", function () {
             assert(FakeTimers.evalCalled);
         });
 
-
-        it("evals non-function callbacks", function () {
-            this.clock.setTimeout("FakeTimers.evalCalled = true", 10);
-            this.clock.tick(10);
-
-            assert(FakeTimers.evalCalled);
-        });
-
-        it("only evals on global scope", function () {
-            var x = 15;
-            try {
-                this.clock.setTimeout("x", x);
-                this.clock.tick(x);
-                assert.fail();
-            } catch (e) {
-                assert(e instanceof ReferenceError);
-            }
-        });
-
         it("passes setTimeout parameters", function () {
             var clock = FakeTimers.createClock();
             var stub = sinon.stub();


### PR DESCRIPTION
#### Purpose

**Not allowing the use of eval in Node.js** - as decided in this discussion: https://github.com/sinonjs/fake-timers/issues/319#issuecomment-632794814

In this pull request using an `eval()` in `Node.js` env will throw an error.
At first, I've seen that there are 4 tests that test things who **do not** require `eval()` at all (thinking about https://github.com/sinonjs/fake-timers/pull/327#discussion_r429342307), I've replaced the strings in these tests with empty functions. 

In addition, I've added 2 `describe()` test blocks to test the use of eval (instead of the previous eval tests - who ignored the environments), once in Node.js and once in other environments. 

I've added a **global variable** that will only exist in a `Node.js` environment


