### PR TITLE
Remove misleading comment

### DIFF
--- a/fake-timers.js
+++ b/fake-timers.js
@@ -105,7 +105,6 @@ module.exports = function every(obj, fn) {
     var pass = true;
 
     try {
-        /* eslint-disable-next-line local-rules/no-prototype-methods */
         obj.forEach(function() {
             if (!fn.apply(this, arguments)) {
                 // Throwing an error is the only way to break `forEach`
@@ -205,7 +204,6 @@ module.exports = copyPrototype(Array.prototype);
 var call = Function.call;
 
 module.exports = function copyPrototypeMethods(prototype) {
-    /* eslint-disable local-rules/no-prototype-methods */
     return Object.getOwnPropertyNames(prototype).reduce(function(result, name) {
         // ignore size because it throws from Map
         if (
@@ -283,7 +281,6 @@ module.exports = function typeOf(value) {
 
 function valueToString(value) {
     if (value && value.toString) {
-        /* eslint-disable-next-line local-rules/no-prototype-methods */
         return value.toString();
     }
     return String(value);


### PR DESCRIPTION
This repository doesn't use the `no-prototype-methods` rule that is
managed with `local-rules` plugin, so the comments make no sense.

ESLint should really throw an error here...

#### How to verify

1. Check out this branch
1. search the codebase for `local-rules`
1. Observe that there are no results