### PR TITLE
Publish .d.ts files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea
 .nyc_output/
 coverage/
+types

--- a/package-lock.json
+++ b/package-lock.json
@@ -7666,6 +7666,12 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typescript": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "dev": true
+    },
     "uglify-js": {
       "version": "3.6.4",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.4.tgz",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "test-cloud": "mochify --wd --no-detect-globals --timeout=10000",
     "test-coverage": "nyc --all --reporter text --reporter html --reporter lcovonly npm run test-node",
     "test": "npm run lint && npm run test-node && npm run test-headless",
-    "bundle": "browserify --no-detect-globals -s FakeTimers -o fake-timers.js src/fake-timers-src.js",
     "prepublishOnly": "npm run build",
     "preversion": "./scripts/preversion.sh",
     "version": "./scripts/version.sh",
@@ -37,7 +36,6 @@
   ],
   "devDependencies": {
     "@sinonjs/referee-sinon": "6.0.1",
-    "browserify": "16.5.0",
     "eslint": "6.8.0",
     "eslint-config-prettier": "6.10.0",
     "eslint-config-sinon": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "license": "BSD-3-Clause",
   "scripts": {
+    "build": "rm -rf types && tsc",
     "lint": "eslint .",
     "test-node": "mocha test/ integration-test/ -R dot --check-leaks",
     "test-headless": "mochify --no-detect-globals --timeout=10000",
@@ -22,7 +23,7 @@
     "test-coverage": "nyc --all --reporter text --reporter html --reporter lcovonly npm run test-node",
     "test": "npm run lint && npm run test-node && npm run test-headless",
     "bundle": "browserify --no-detect-globals -s FakeTimers -o fake-timers.js src/fake-timers-src.js",
-    "prepublishOnly": "npm run bundle",
+    "prepublishOnly": "npm run build",
     "preversion": "./scripts/preversion.sh",
     "version": "./scripts/version.sh",
     "postversion": "./scripts/postversion.sh"
@@ -32,7 +33,7 @@
   },
   "files": [
     "src/",
-    "fake-timers.js"
+    "types"
   ],
   "devDependencies": {
     "@sinonjs/referee-sinon": "6.0.1",
@@ -50,7 +51,8 @@
     "mochify": "6.6.0",
     "npm-run-all": "4.1.5",
     "nyc": "14.1.1",
-    "prettier": "1.19.1"
+    "prettier": "1.19.1",
+    "typescript": "4.1.3"
   },
   "eslintConfig": {
     "extends": "eslint-config-sinon",
@@ -74,6 +76,7 @@
   },
   "module": "./fake-timers.js",
   "main": "./src/fake-timers-src.js",
+  "types": "./types/fake-timers-src.d.ts",
   "dependencies": {
     "@sinonjs/commons": "^1.7.0"
   },
@@ -90,6 +93,7 @@
     "exclude": [
       "**/*-test.js",
       "coverage/**",
+      "types/**",
       "fake-timers.js"
     ]
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "include": [
+      "src/*.js"
+  ],
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "allowJs": true,
+    "outDir": "types"
+  }
+}


### PR DESCRIPTION
In order to improve the experience of TypeScript users, we are compiling
`.d.ts` files from the JSDoc and distributing them with the package

This PR drops the bundled version, as we believe that to be entirely unnecessary.

#### Background

* We'd like to ship the library with `.d.ts` files, to allow improved experience for TypeScript users

#### Solution

* Create `.d.ts` files from the source files

#### How to verify

1. Check out this branch
1. `npm ci`
1. `npm run build`
1. Observe that there are `.d.ts` files in the `types/` folder
2. `npm pack`
3. Observe that the `.d.ts` files are included in the package
4. `npm link`
5. In a `sinon` checkout:
    1.  `npm link @sinonjs/fake-timers`
    2. `npm test`
    3. Observe that tests still pass