### PR TITLE
Remove Object.keys polyfill

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -634,21 +634,6 @@ function withGlobal(_global) {
         timers.cancelIdleCallback = _global.cancelIdleCallback;
     }
 
-    var keys =
-        Object.keys ||
-        function(obj) {
-            var ks = [];
-            var key;
-
-            for (key in obj) {
-                if (obj.hasOwnProperty(key)) {
-                    ks.push(key);
-                }
-            }
-
-            return ks;
-        };
-
     var originalSetTimeout = _global.setImmediate || _global.setTimeout;
 
     /**
@@ -1073,7 +1058,7 @@ function withGlobal(_global) {
                     return clock.now;
                 }
 
-                numTimers = keys(clock.timers).length;
+                numTimers = Object.keys(clock.timers).length;
                 if (numTimers === 0) {
                     return clock.now;
                 }
@@ -1271,7 +1256,7 @@ function withGlobal(_global) {
 
         if (clock.methods.length === 0) {
             // do not fake nextTick by default - GitHub#126
-            clock.methods = keys(timers).filter(function(key) {
+            clock.methods = Object.keys(timers).filter(function(key) {
                 return key !== "nextTick" && key !== "queueMicrotask";
             });
         }


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Fix inconsistent use of `Object.keys` and `keys` polyfill.

#### Background (Problem in detail)  - optional

While considering how to implement `Object.assign`, I noticed that `Object.keys` is used in some places and the `keys` conditional polyfill is used in others.  This intent is unclear (although after reviewing the history I assume it was left over from previous compatibility requirements) and it seemed to present needless complexity and maintenance burden.

#### Solution  - optional

The current [sinon compatibility] specifies that "the source is written as ES5.1", which defines [Object.keys].  This PR replaces the two remaining uses of the polyfill and removes it to reduce.

#### Alternate Solution

If there is reason to keep the polyfill, I could send a PR to use it everywhere, move it to [commons](https://github.com/kevinoid/commons), and/or add comments to explain why the use is necessary.

[sinon compatibility]: https://github.com/sinonjs/sinon/blob/master/COMPATIBILITY.md
[Object.keys]: https://www.ecma-international.org/ecma-262/5.1/#sec-15.2.3.14