### PR TITLE
Simplify pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test-check-coverage": "npm run test-coverage && nyc check-coverage",
     "test-cloud": "mochify --wd --no-detect-globals --timeout=10000",
     "test-coverage": "nyc --all --reporter text --reporter html --reporter lcovonly npm run test-node",
-    "test": "npm run lint && npm run test-node && npm run test-headless",
+    "test": "npm run test-node && npm run test-headless",
     "prepublishOnly": "npm run build",
     "preversion": "./scripts/preversion.sh",
     "version": "./scripts/version.sh",
@@ -78,7 +78,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run lint && npm run test-node"
+      "pre-commit": "npm run lint"
     }
   },
   "nyc": {

--- a/scripts/preversion.sh
+++ b/scripts/preversion.sh
@@ -10,6 +10,7 @@ if [ -z $SAUCE_ACCESS_KEY ]; then
     exit 1
 fi
 
+npm run lint
 npm test # lints and tests
 
 npm run test-cloud # should not take more than approx 25 seconds


### PR DESCRIPTION
We don't need to run all the tests all the time. With CI we get fast feedback and prevent accidental merging of bad branches

This removes some of the frustrating parts of working in this library.