### PR TITLE
Make config properties optional in TypeScript defs

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -1212,12 +1212,18 @@ function withGlobal(_global) {
     }
 
     /**
-     * @param config {Object} optional config
-     * @param config.now {number|Date}  a number (in milliseconds) or a Date object (default epoch)
-     * @param config.toFake {string[]} names of the methods that should be faked.
-     * @param config.loopLimit {number} the maximum number of timers that will be run when calling runAll()
-     * @param config.shouldAdvanceTime {Boolean} tells FakeTimers to increment mocked time automatically (default false)
-     * @param config.advanceTimeDelta {Number} increment mocked time every <<advanceTimeDelta>> ms (default: 20ms)
+     * Configuration object for the `install` method.
+     *
+     * @typedef {object} Config
+     * @property [now] {number|Date}  a number (in milliseconds) or a Date object (default epoch)
+     * @property [toFake] {string[]} names of the methods that should be faked.
+     * @property [loopLimit] {number} the maximum number of timers that will be run when calling runAll()
+     * @property [shouldAdvanceTime] {Boolean} tells FakeTimers to increment mocked time automatically (default false)
+     * @property [advanceTimeDelta] {Number} increment mocked time every <<advanceTimeDelta>> ms (default: 20ms)
+     */
+
+    /**
+     * @param [config] {Config} optional config
      */
     // eslint-disable-next-line complexity
     function install(config) {


### PR DESCRIPTION
#### Purpose (TL;DR)

We make the configuration argument for `install` and all configuration properties optional in the TypeScript definition. This fixes #352.

#### Background

As described in #352, the type definitions generated from the JSDoc comments required the config object with all parameters when calling `install`. All of these parameters are optional however.

#### Solution

It was necessary to create a JSDoc `@typedef` section because TypeScript is not able to generate the intended types from

    @param [config.now] {number|Date}

