### PR TITLE
Change the protocol for all URLs to https://

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-; EditorConfig file: http://EditorConfig.org
+; EditorConfig file: https://EditorConfig.org
 ; Install the "EditorConfig" plugin into your editor to use
 
 root = true

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Please note that this project is released with a [Contributor Code of Conduct](.
 
 ## Use EditorConfig
 
-To save everyone some time, please use [EditorConfig](http://editorconfig.org), so your editor helps make
+To save everyone some time, please use [EditorConfig](https://editorconfig.org), so your editor helps make
 sure we all use the same encoding, indentation, line endings, etc.
 
 ## Compatibility

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ clock.tick(15);
 ```
 
 Upon executing the last line, an interesting fact about the
-[Poblano](http://en.wikipedia.org/wiki/Poblano) will be printed synchronously to
+[Poblano](https://en.wikipedia.org/wiki/Poblano) will be printed synchronously to
 the screen. If you want to simulate asynchronous behavior, you have to use your
 imagination when calling the various functions.
 

--- a/package.json
+++ b/package.json
@@ -2,15 +2,15 @@
   "name": "@sinonjs/fake-timers",
   "description": "Fake JavaScript timers",
   "version": "7.0.3",
-  "homepage": "http://github.com/sinonjs/fake-timers",
+  "homepage": "https://github.com/sinonjs/fake-timers",
   "author": "Christian Johansen",
   "repository": {
     "type": "git",
-    "url": "http://github.com/sinonjs/fake-timers.git"
+    "url": "https://github.com/sinonjs/fake-timers.git"
   },
   "bugs": {
     "mail": "christian@cjohansen.no",
-    "url": "http://github.com/sinonjs/fake-timers/issues"
+    "url": "https://github.com/sinonjs/fake-timers/issues"
   },
   "license": "BSD-3-Clause",
   "scripts": {

--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -80,7 +80,7 @@ function withGlobal(_global) {
         _global.setImmediate && typeof _global.setImmediate === "function";
 
     // Make properties writable in IE, as per
-    // http://www.adequatelygood.com/Replacing-setTimeout-Globally.html
+    // https://www.adequatelygood.com/Replacing-setTimeout-Globally.html
     /* eslint-disable no-self-assign */
     if (isRunningInIE) {
         _global.setTimeout = _global.setTimeout;


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

This is more secure. Also the inconsistency when running `yarn outdated`  bugged me.

#### Solution  - optional

Replace all `http://` URLs with `https://`. I verified all changed URLs work with https.
