### PR TITLE
Fix refresh arguments forwarding

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -361,7 +361,8 @@ function withGlobal(_global) {
                 },
                 refresh: function () {
                     clearTimeout(timer.id);
-                    return setTimeout(timer.func, timer.delay);
+                    var args = [ timer.func, timer.delay ].concat(timer.args);
+                    return setTimeout.apply(null, args);
                 },
             };
             return res;

--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -361,7 +361,7 @@ function withGlobal(_global) {
                 },
                 refresh: function () {
                     clearTimeout(timer.id);
-                    var args = [ timer.func, timer.delay ].concat(timer.args);
+                    var args = [timer.func, timer.delay].concat(timer.args);
                     return setTimeout.apply(null, args);
                 },
             };

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -4655,6 +4655,23 @@ describe("issue #315 - praseInt if delay is not a number", function () {
     });
 });
 
+describe("#368 - timeout.refresh setTimeout arguments", function () {
+  it("should forward  argumnts passed to setTimeout", function () {
+    var clock = FakeTimers.install();
+    var stub = sinon.stub();
+
+    if (typeof setTimeout(NOOP, 0) === "object") {
+    var t = setTimeout(stub, 1000, "test");
+      clock.tick(1000);
+      t.refresh();
+      clock.tick(1000);
+      assert.calledTwice(stub);
+      assert.alwaysCalledWith(stub, "test");
+    }
+    clock.uninstall();
+  });
+});
+
 describe("#187 - Support timeout.refresh in node environments", function () {
     it("calls the stub again after refreshing the timeout", function () {
         var clock = FakeTimers.install();

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -4656,20 +4656,23 @@ describe("issue #315 - praseInt if delay is not a number", function () {
 });
 
 describe("#368 - timeout.refresh setTimeout arguments", function () {
-  it("should forward  arguments passed to setTimeout", function () {
-    var clock = FakeTimers.install();
-    var stub = sinon.stub();
+    before(function () {
+        if (!addTimerReturnsObject) {
+            this.skip();
+        }
+    });
+    it("should forward  arguments passed to setTimeout", function () {
+        var clock = FakeTimers.install();
+        var stub = sinon.stub();
 
-    if (typeof setTimeout(NOOP, 0) === "object") {
-    var t = setTimeout(stub, 1000, "test");
-      clock.tick(1000);
-      t.refresh();
-      clock.tick(1000);
-      assert.calledTwice(stub);
-      assert.alwaysCalledWith(stub, "test");
-    }
-    clock.uninstall();
-  });
+        var t = setTimeout(stub, 1000, "test");
+        clock.tick(1000);
+        t.refresh();
+        clock.tick(1000);
+        assert.calledTwice(stub);
+        assert.alwaysCalledWith(stub, "test");
+        clock.uninstall();
+    });
 });
 
 describe("#187 - Support timeout.refresh in node environments", function () {

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -4656,7 +4656,7 @@ describe("issue #315 - praseInt if delay is not a number", function () {
 });
 
 describe("#368 - timeout.refresh setTimeout arguments", function () {
-  it("should forward  argumnts passed to setTimeout", function () {
+  it("should forward  arguments passed to setTimeout", function () {
     var clock = FakeTimers.install();
     var stub = sinon.stub();
 


### PR DESCRIPTION
#### Purpose (TL;DR)

Refresh wasn't forwarding the arguments passed to setTimeout.
 
Fixes #368 
<!--
> give a concise (one or two short sentences) description of what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->

<!--
#### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->

<!--
#### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->
