### PR TITLE
Drop IE11 and Safari 9 from Sauce Labs test runners

### DIFF
--- a/.min-wd
+++ b/.min-wd
@@ -2,5 +2,9 @@
   "sauceLabs": true,
   "browsers": [{
     "name": "firefox"
+  }, {
+    "name": "MicrosoftEdge"
+  }, {
+    "name": "safari"
   }]
 }

--- a/.min-wd
+++ b/.min-wd
@@ -2,12 +2,5 @@
   "sauceLabs": true,
   "browsers": [{
     "name": "firefox"
-  }, {
-    "name": "internet explorer",
-    "version": "11"
-  }, {
-    "name": "safari",
-    "platform": "OS X 10.11",
-    "version": "9.0"
   }]
 }


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

- Drop IE11 and Safari 9 per discussion in #375 and sinonjs/sinon#2359.
- Also copies in browsers from the mother Sinon repo to include Edge and Safari latest

#### Background (Problem in detail)  - optional
See discussion in #375 and sinonjs/sinon#2359