### PR TITLE
Fix JSDoc for createClock

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -731,8 +731,8 @@ function withGlobal(_global) {
     var originalSetTimeout = _global.setImmediate || _global.setTimeout;
 
     /**
-     * @param {Date|number} start the system time - non-integer values are floored
-     * @param {number} loopLimit maximum number of timers that will be run when calling runAll()
+     * @param {Date|number} [start] the system time - non-integer values are floored
+     * @param {number} [loopLimit] maximum number of timers that will be run when calling runAll()
      * @returns {Clock}
      */
     function createClock(start, loopLimit) {
@@ -1309,7 +1309,7 @@ function withGlobal(_global) {
     /* eslint-disable complexity */
 
     /**
-     * @param {Config=} config Optional config
+     * @param {Config=} [config] Optional config
      * @returns {Clock}
      */
     function install(config) {


### PR DESCRIPTION
This improves the generated .d.ts so that createClock may be called without arguments.

#### Purpose (TL;DR) - mandatory

Improve .d.ts types for `createClock()` so that it's possible to call it from TypeScript without arguments.
<!--
> give a concise (one or two short sentences) description of what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->

<!--
#### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->

The currently generated .d.ts uses JSDoc, which incorrectly specified the two arguments for `createClock()` as mandatory.

<!--
#### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->
