### PR TITLE
Update eslint config

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,15 +1,5 @@
 extends:
-  - sinon
-
-plugins:
-  - ie11
-
-rules:
-  ie11/no-collection-args: error
-  ie11/no-for-in-const: error
-  ie11/no-loop-func: warn
-  ie11/no-weak-collections: error
-  prettier/prettier: off
+  - "@sinonjs/eslint-config"
 
 overrides:
   - files: "**/*-test.js"
@@ -20,7 +10,7 @@ overrides:
     rules:
       max-nested-callbacks: off
       mocha/no-exclusive-tests: error
-  - files: "**/*.ts"
+  - files: "test/**.ts"
     parserOptions:
       ecmaVersion: 2020
       sourceType: 'module'

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,12 @@
         "@babel/types": "^7.4.4"
       }
     },
+    "@babel/helper-validator-identifier": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
+      "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+      "dev": true
+    },
     "@babel/highlight": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
@@ -128,6 +134,58 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@eslint/eslintrc": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.1.tgz",
+      "integrity": "sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
+      }
+    },
+    "@mdn/browser-compat-data": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-2.0.7.tgz",
+      "integrity": "sha512-GeeM827DlzFFidn1eKkMBiqXFD2oLsnZbaiGhByPl0vcapsRzUL+t9hDoov1swc9rB2jw64R+ihtzC8qOE9wXw==",
+      "dev": true,
+      "requires": {
+        "extend": "3.0.2"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
@@ -175,6 +233,18 @@
       "integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
       "requires": {
         "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/eslint-config": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/eslint-config/-/eslint-config-4.0.2.tgz",
+      "integrity": "sha512-r7niZxl1vi6AyRjfSKZv1RrLDhfi3jAo8syCtDkY3RjRzweeu+r2Vgx8StLoBTCeKWLjKy6lYwWO4Y/OhHTVbw==",
+      "dev": true,
+      "requires": {
+        "eslint": "^7.20.0",
+        "eslint-plugin-compat": "^3.9.0",
+        "eslint-plugin-jsdoc": "^32.2.0",
+        "eslint-plugin-mocha": "^8.0.0"
       }
     },
     "@sinonjs/formatio": {
@@ -321,9 +391,9 @@
       }
     },
     "acorn-jsx": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
-      "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
       "dev": true
     },
     "acorn-node": {
@@ -353,12 +423,12 @@
       }
     },
     "ajv": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
@@ -574,10 +644,16 @@
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
+    "ast-metadata-inferer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.4.0.tgz",
+      "integrity": "sha512-tKHdBe8N/Vq2nLAm4YPBVREVZjMux6KrqyPfNQgIbDl0t7HaNSmy8w4OyVHYg/cvyn5BW7o7pVwpjPte89Zhcg==",
+      "dev": true
+    },
     "astral-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
     "async-each": {
@@ -1122,6 +1198,19 @@
         "pako": "~1.0.5"
       }
     },
+    "browserslist": {
+      "version": "4.16.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001219",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.723",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.71"
+      }
+    },
     "buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
@@ -1237,6 +1326,12 @@
         "quick-lru": "^4.0.1"
       }
     },
+    "caniuse-lite": {
+      "version": "1.0.30001230",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz",
+      "integrity": "sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==",
+      "dev": true
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -1252,12 +1347,6 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
-    },
-    "chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
     },
     "chokidar": {
       "version": "2.1.8",
@@ -1400,12 +1489,6 @@
         }
       }
     },
-    "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-      "dev": true
-    },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -1479,6 +1562,12 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "colorette": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+      "dev": true
+    },
     "combine-source-map": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
@@ -1504,6 +1593,12 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true
+    },
+    "comment-parser": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.1.5.tgz",
+      "integrity": "sha512-RePCE4leIhBlmrqiYTvaqEeGYg7qpSl4etaIabKtdOQVi+mSTIBBklGUwIr79GXYnl3LpMwmDw4KeR2stNc6FA==",
       "dev": true
     },
     "commondir": {
@@ -1620,6 +1715,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.13.0.tgz",
+      "integrity": "sha512-iWDbiyha1M5vFwPFmQnvRv+tJzGbFAm6XimJUT0NgHYW3xZEs1SkCAcasWSVFxpI2Xb/V1DDJckq3v90+bQnog==",
       "dev": true
     },
     "core-util-is": {
@@ -1798,16 +1899,25 @@
       }
     },
     "cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
       "dev": true,
       "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "dependencies": {
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "crypto-browserify": {
@@ -2185,6 +2295,12 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "electron-to-chromium": {
+      "version": "1.3.741",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.741.tgz",
+      "integrity": "sha512-4i3T0cwnHo1O4Mnp9JniEco8bZiXoqbm3PhW5hv7uu8YLg35iajYrRnNyKFaN8/8SSTskU2hYqVTeYVPceSpUA==",
+      "dev": true
+    },
     "elegant-spinner": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
@@ -2233,6 +2349,15 @@
       "dev": true,
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
       }
     },
     "error-ex": {
@@ -2316,63 +2441,161 @@
       }
     },
     "eslint": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
-      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.27.0.tgz",
+      "integrity": "sha512-JZuR6La2ZF0UD384lcbnd0Cgg6QJjiCwhMD6eU4h/VGPcVGwawNNzKU41tgokGXnfjOOyI6QIffthhJTPzzuRA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
+        "@babel/code-frame": "7.12.11",
+        "@eslint/eslintrc": "^0.4.1",
         "ajv": "^6.10.0",
-        "chalk": "^2.1.0",
-        "cross-spawn": "^6.0.5",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
-        "eslint-scope": "^5.0.0",
-        "eslint-utils": "^1.4.3",
-        "eslint-visitor-keys": "^1.1.0",
-        "espree": "^6.1.2",
-        "esquery": "^1.0.1",
+        "enquirer": "^2.3.5",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.1",
+        "esquery": "^1.4.0",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^5.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
-        "globals": "^12.1.0",
+        "globals": "^13.6.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^7.0.0",
         "is-glob": "^4.0.0",
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
-        "lodash": "^4.17.14",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
         "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.8.3",
+        "optionator": "^0.9.1",
         "progress": "^2.0.0",
-        "regexpp": "^2.0.1",
-        "semver": "^6.1.2",
-        "strip-ansi": "^5.2.0",
-        "strip-json-comments": "^3.0.1",
-        "table": "^5.2.3",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^6.0.9",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+        "@babel/code-frame": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+          "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "@babel/highlight": "^7.10.4"
           }
         },
+        "@babel/highlight": {
+          "version": "7.14.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
+          "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.0",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
+            }
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^2.0.1"
+              }
+            },
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
         "glob-parent": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-          "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
           "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
@@ -2390,42 +2613,99 @@
           }
         },
         "globals": {
-          "version": "12.3.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-          "integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+          "version": "13.9.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
+          "integrity": "sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==",
           "dev": true,
           "requires": {
-            "type-fest": "^0.8.1"
+            "type-fest": "^0.20.2"
           }
         },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "levn": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+          "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1",
+            "type-check": "~0.4.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "optionator": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+          "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+          "dev": true,
+          "requires": {
+            "deep-is": "^0.1.3",
+            "fast-levenshtein": "^2.0.6",
+            "levn": "^0.4.1",
+            "prelude-ls": "^1.2.1",
+            "type-check": "^0.4.0",
+            "word-wrap": "^1.2.3"
+          }
+        },
+        "prelude-ls": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+          "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "type-check": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+          "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1"
+          }
+        },
         "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "dev": true
         }
       }
-    },
-    "eslint-config-prettier": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
-      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
-      "dev": true,
-      "requires": {
-        "get-stdin": "^6.0.0"
-      }
-    },
-    "eslint-config-sinon": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-sinon/-/eslint-config-sinon-3.0.1.tgz",
-      "integrity": "sha512-hHEHWZjqxhqKN5N3r6542YHU5OLtSOJDWYeAfbMLzqn/QWMNROjMaZzm5GlmOfgFFxviQ5wsOz3lxKTrfR8KwQ==",
-      "dev": true
     },
     "eslint-formatter-pretty": {
       "version": "4.0.0",
@@ -2550,31 +2830,104 @@
         }
       }
     },
-    "eslint-plugin-ie11": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-ie11/-/eslint-plugin-ie11-1.0.0.tgz",
-      "integrity": "sha512-PPv2Cbq5roUmoIZJfPWbEEILHvi2Yfp/cRVzaVKL/YJiYGGLJ0/Qrq1HKd2OZKb3RQQOXweCd/hh261bljEe8A==",
+    "eslint-plugin-compat": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-3.9.0.tgz",
+      "integrity": "sha512-lt3l5PHFHVEYSZ5zijcoYvtQJPsBifRiH5N0Et57KwVu7l/yxmHhSG6VJiLMa/lXrg93Qu8049RNQOMn0+yJBg==",
       "dev": true,
       "requires": {
-        "requireindex": "~1.1.0"
+        "@mdn/browser-compat-data": "^2.0.7",
+        "ast-metadata-inferer": "^0.4.0",
+        "browserslist": "^4.12.2",
+        "caniuse-lite": "^1.0.30001166",
+        "core-js": "^3.6.5",
+        "find-up": "^4.1.0",
+        "lodash.memoize": "4.1.2",
+        "semver": "7.3.2"
+      },
+      "dependencies": {
+        "lodash.memoize": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+          "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-32.3.4.tgz",
+      "integrity": "sha512-xSWfsYvffXnN0OkwLnB7MoDDDDjqcp46W7YlY1j7JyfAQBQ+WnGCfLov3gVNZjUGtK9Otj8mEhTZTqJu4QtIGA==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "1.1.5",
+        "debug": "^4.3.1",
+        "jsdoctypeparser": "^9.0.0",
+        "lodash": "^4.17.21",
+        "regextras": "^0.7.1",
+        "semver": "^7.3.5",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+          "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+          "dev": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-mocha": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-6.2.2.tgz",
-      "integrity": "sha512-oNhPzfkT6Q6CJ0HMVJ2KLxEWG97VWGTmuHOoRcDLE0U88ugUyFNV9wrT2XIt5cGtqc5W9k38m4xTN34L09KhBA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-8.2.0.tgz",
+      "integrity": "sha512-8oOR47Ejt+YJPNQzedbiklDqS1zurEaNrxXpRs+Uk4DMDPVmKNagShFeUaYsfvWP55AhI+P1non5QZAHV6K78A==",
       "dev": true,
       "requires": {
-        "ramda": "^0.26.1"
-      }
-    },
-    "eslint-plugin-prettier": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.1.tgz",
-      "integrity": "sha512-A+TZuHZ0KU0cnn56/9mfR7/KjUJ9QNVXUhwvRFSR7PGPe0zQR6PTkmyqg1AtUUEOzTqeRsUwyKFh0oVZKVCrtA==",
-      "dev": true,
-      "requires": {
-        "prettier-linter-helpers": "^1.0.0"
+        "eslint-utils": "^2.1.0",
+        "ramda": "^0.27.1"
       }
     },
     "eslint-rule-docs": {
@@ -2584,39 +2937,55 @@
       "dev": true
     },
     "eslint-scope": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
+        "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
       }
     },
     "eslint-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true
     },
     "espree": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
-      "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
       "dev": true,
       "requires": {
-        "acorn": "^7.1.0",
-        "acorn-jsx": "^5.1.0",
-        "eslint-visitor-keys": "^1.1.0"
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^1.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
       }
     },
     "esprima": {
@@ -2626,27 +2995,43 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
       }
     },
     "esrecurse": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
       }
     },
     "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
     "esutils": {
@@ -2814,17 +3199,6 @@
         }
       }
     },
-    "external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dev": true,
-      "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      }
-    },
     "extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -2940,15 +3314,9 @@
       }
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
-    },
-    "fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
     "fast-glob": {
@@ -3081,12 +3449,12 @@
       }
     },
     "file-entry-cache": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
       "requires": {
-        "flat-cache": "^2.0.1"
+        "flat-cache": "^3.0.4"
       }
     },
     "file-uri-to-path": {
@@ -3201,20 +3569,30 @@
       "dev": true
     },
     "flat-cache": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
       "dev": true,
       "requires": {
-        "flatted": "^2.0.0",
-        "rimraf": "2.6.3",
-        "write": "1.0.3"
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flatted": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
+      "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
       "dev": true
     },
     "for-in": {
@@ -3328,12 +3706,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
       "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
-      "dev": true
-    },
-    "get-stdin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
     },
     "get-stream": {
@@ -3916,123 +4288,6 @@
         "source-map": "~0.5.3"
       }
     },
-    "inquirer": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.4.tgz",
-      "integrity": "sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^2.4.2",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.15",
-        "mute-stream": "0.0.8",
-        "run-async": "^2.2.0",
-        "rxjs": "^6.5.3",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^5.1.0",
-        "through": "^2.3.6"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
-          "integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
-          "dev": true,
-          "requires": {
-            "type-fest": "^0.8.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "cli-cursor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "^3.1.0"
-          }
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
-        "figures": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
-          "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "^1.0.5"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
-        "restore-cursor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-          "dev": true,
-          "requires": {
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-              "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^5.0.0"
-              }
-            }
-          }
-        },
-        "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-          "dev": true
-        }
-      }
-    },
     "insert-module-globals": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.2.1.tgz",
@@ -4443,6 +4698,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "jsdoctypeparser": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz",
+      "integrity": "sha512-jrTA2jJIL6/DAEILBEh2/w9QxCuwmvNXIry39Ay/HVfhE3o2yVV0U44blYkqdHA/OKloJEqvJy0xU+GSdE2SIw==",
       "dev": true
     },
     "jsdom": {
@@ -4910,6 +5171,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -4938,6 +5205,18 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
       "dev": true
     },
     "log-symbols": {
@@ -6010,12 +6289,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-      "dev": true
-    },
     "nan": {
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
@@ -6066,12 +6339,6 @@
       "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
       "dev": true
     },
-    "nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
-    },
     "nise": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/nise/-/nise-3.0.1.tgz",
@@ -6090,6 +6357,12 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
+    },
+    "node-releases": {
+      "version": "1.1.72",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
+      "integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
       "dev": true
     },
     "normalize-package-data": {
@@ -6343,12 +6616,6 @@
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
-    },
     "outpipe": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
@@ -6524,9 +6791,9 @@
       "dev": true
     },
     "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
     "path-parse": {
@@ -6654,15 +6921,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
       "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
       "dev": true
-    },
-    "prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "dev": true,
-      "requires": {
-        "fast-diff": "^1.1.2"
-      }
     },
     "process": {
       "version": "0.11.10",
@@ -6840,9 +7098,9 @@
       "dev": true
     },
     "ramda": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
-      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
       "dev": true
     },
     "randombytes": {
@@ -7011,9 +7269,15 @@
       }
     },
     "regexpp": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "dev": true
+    },
+    "regextras": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.7.1.tgz",
+      "integrity": "sha512-9YXf6xtW+qzQ+hcMQXx95MOvfqXFgsKDZodX3qZB0x2n5Z94ioetIITsBtvJbiOyxa/6s9AtyweBLCdPmPko/w==",
       "dev": true
     },
     "registry-auth-token": {
@@ -7157,16 +7421,16 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
-    },
-    "requireindex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
-      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI=",
       "dev": true
     },
     "resolve": {
@@ -7256,15 +7520,6 @@
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
-      }
-    },
-    "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "dev": true,
-      "requires": {
-        "is-promise": "^2.1.0"
       }
     },
     "run-parallel": {
@@ -7427,18 +7682,18 @@
       }
     },
     "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "^3.0.0"
       }
     },
     "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
     "shell-quote": {
@@ -7504,14 +7759,46 @@
       "dev": true
     },
     "slice-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
-      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "astral-regex": "^1.0.0",
-        "is-fullwidth-code-point": "^2.0.0"
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        }
       }
     },
     "snapdragon": {
@@ -7969,9 +8256,9 @@
       }
     },
     "strip-json-comments": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-      "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
     "subarg": {
@@ -8040,44 +8327,73 @@
       }
     },
     "table": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
-      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
+      "integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
       "dev": true,
       "requires": {
-        "ajv": "^6.10.2",
-        "lodash": "^4.17.14",
-        "slice-ansi": "^2.1.0",
-        "string-width": "^3.0.0"
+        "ajv": "^8.0.1",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
         "ajv": {
-          "version": "6.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
-          "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz",
+          "integrity": "sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
             "uri-js": "^4.2.2"
           }
         },
-        "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
           "dev": true
         },
         "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
           }
         }
       }
@@ -8167,15 +8483,6 @@
       "dev": true,
       "requires": {
         "process": "~0.11.0"
-      }
-    },
-    "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "~1.0.2"
       }
     },
     "to-fast-properties": {
@@ -8686,9 +8993,9 @@
       "dev": true
     },
     "v8-compile-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
-      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -8906,15 +9213,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
-    },
-    "write": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
-      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
-      "dev": true,
-      "requires": {
-        "mkdirp": "^0.5.1"
-      }
     },
     "write-file-atomic": {
       "version": "2.4.3",

--- a/package.json
+++ b/package.json
@@ -39,13 +39,8 @@
     "types"
   ],
   "devDependencies": {
+    "@sinonjs/eslint-config": "4.0.2",
     "@sinonjs/referee-sinon": "6.0.1",
-    "eslint": "6.8.0",
-    "eslint-config-prettier": "6.10.0",
-    "eslint-config-sinon": "3.0.1",
-    "eslint-plugin-ie11": "1.0.0",
-    "eslint-plugin-mocha": "6.2.2",
-    "eslint-plugin-prettier": "3.1.1",
     "husky": "4.2.1",
     "jsdom": "16.5.2",
     "lint-staged": "10.0.7",

--- a/test/check-types.ts
+++ b/test/check-types.ts
@@ -21,16 +21,7 @@ FakeTimers.createClock(new Date(), 10);
 clock1.uninstall();
 
 // timers
-FakeTimers.timers.setInterval(
-    () => {
-        return 42;
-    },
-    10,
-    1,
-    2,
-    3,
-    4
-);
+FakeTimers.timers.setInterval(() => 42, 10, 1, 2, 3, 4);
 
 // withContext
 const clock2 = FakeTimers.withGlobal({}).install();
@@ -38,6 +29,6 @@ clock2.uninstall();
 
 // clock.*
 clock1.runToLast();
-async () => await clock1.runToLastAsync();
+clock1.runToLastAsync();
 clock1.runToFrame();
 clock1.setInterval((myArg) => myArg, 42, 100000);

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -55,16 +55,14 @@ var timeoutResult = global.setTimeout(NOOP, 0);
 var addTimerReturnsObject = typeof timeoutResult === "object";
 
 describe("issue #59", function () {
-    var setTimeoutFake = sinon.fake();
-    var context = {
-        Date: Date,
-        setTimeout: setTimeoutFake,
-        clearTimeout: sinon.fake(),
-    };
-    var clock;
-
     it("should install and uninstall the clock on a custom target", function () {
-        clock = FakeTimers.withGlobal(context).install();
+        const setTimeoutFake = sinon.fake();
+        const context = {
+            Date: Date,
+            setTimeout: setTimeoutFake,
+            clearTimeout: sinon.fake(),
+        };
+        const clock = FakeTimers.withGlobal(context).install();
         assert.equals(setTimeoutFake.callCount, 1);
         clock.setTimeout(NOOP, 0);
         assert.equals(setTimeoutFake.callCount, 1);
@@ -504,11 +502,7 @@ describe("FakeTimers", function () {
                         this.clock.setTimeout(notTypeofFunction, 10);
                     }.bind(this),
                     {
-                        message:
-                            "[ERR_INVALID_CALLBACK]: Callback must be a function. Received " +
-                            notTypeofFunction +
-                            " of type " +
-                            typeof notTypeofFunction,
+                        message: `[ERR_INVALID_CALLBACK]: Callback must be a function. Received ${notTypeofFunction} of type ${typeof notTypeofFunction}`,
                     }
                 );
             });

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -1,9 +1,3 @@
-/**
- * @author Christian Johansen (christian@cjohansen.no)
- * @license BSD
- *
- * Copyright (c) 2010-2014 Christian Johansen
- */
 /* eslint-disable no-empty-function */
 "use strict";
 
@@ -51,6 +45,8 @@ var performanceMarkPresent =
 var setImmediatePresent =
     global.setImmediate && typeof global.setImmediate === "function";
 var utilPromisify = global.process && require("util").promisify;
+var promisePresent = typeof global.Promise !== "undefined";
+var utilPromisifyAvailable = promisePresent && utilPromisify;
 var timeoutResult = global.setTimeout(NOOP, 0);
 var addTimerReturnsObject = typeof timeoutResult === "object";
 
@@ -508,35 +504,39 @@ describe("FakeTimers", function () {
             });
         });
 
-        if (typeof global.Promise !== "undefined" && utilPromisify) {
-            describe("when util.promisified", function () {
-                it("sets timers on instance", function () {
-                    var resolved = false;
-                    utilPromisify(this.clock.setTimeout)(100).then(function () {
-                        resolved = true;
-                    });
+        describe("when util.promisified", function () {
+            before(function () {
+                if (!utilPromisifyAvailable) {
+                    this.skip();
+                }
+            });
 
-                    return this.clock.tickAsync(100).then(function () {
-                        assert.isTrue(resolved);
-                    });
+            it("sets timers on instance", function () {
+                var resolved = false;
+                utilPromisify(this.clock.setTimeout)(100).then(function () {
+                    resolved = true;
                 });
 
-                it("resolves with the first additional argument to setTimeout", function () {
-                    var resolvedValue;
-                    utilPromisify(this.clock.setTimeout)(
-                        100,
-                        "the first",
-                        "the second"
-                    ).then(function (value) {
-                        resolvedValue = value;
-                    });
-
-                    return this.clock.tickAsync(100).then(function () {
-                        assert.equals(resolvedValue, "the first");
-                    });
+                return this.clock.tickAsync(100).then(function () {
+                    assert.isTrue(resolved);
                 });
             });
-        }
+
+            it("resolves with the first additional argument to setTimeout", function () {
+                var resolvedValue;
+                utilPromisify(this.clock.setTimeout)(
+                    100,
+                    "the first",
+                    "the second"
+                ).then(function (value) {
+                    resolvedValue = value;
+                });
+
+                return this.clock.tickAsync(100).then(function () {
+                    assert.equals(resolvedValue, "the first");
+                });
+            });
+        });
     });
 
     describe("setImmediate", function () {
@@ -620,34 +620,37 @@ describe("FakeTimers", function () {
             clock.tick(0);
         });
 
-        if (typeof global.Promise !== "undefined" && utilPromisify) {
-            describe("when util.promisified", function () {
-                it("calls the given callback immediately", function () {
-                    var resolved = false;
-                    utilPromisify(this.clock.setImmediate)().then(function () {
-                        resolved = true;
-                    });
-
-                    return this.clock.tickAsync(0).then(function () {
-                        assert.isTrue(resolved);
-                    });
+        describe("when util.promisified", function () {
+            before(function () {
+                if (!utilPromisifyAvailable) {
+                    this.skip();
+                }
+            });
+            it("calls the given callback immediately", function () {
+                var resolved = false;
+                utilPromisify(this.clock.setImmediate)().then(function () {
+                    resolved = true;
                 });
 
-                it("resolves with the first argument to setImmediate", function () {
-                    var resolvedValue;
-                    utilPromisify(this.clock.setImmediate)(
-                        "the first",
-                        "the second"
-                    ).then(function (value) {
-                        resolvedValue = value;
-                    });
-
-                    return this.clock.tickAsync(0).then(function () {
-                        assert.equals(resolvedValue, "the first");
-                    });
+                return this.clock.tickAsync(0).then(function () {
+                    assert.isTrue(resolved);
                 });
             });
-        }
+
+            it("resolves with the first argument to setImmediate", function () {
+                var resolvedValue;
+                utilPromisify(this.clock.setImmediate)(
+                    "the first",
+                    "the second"
+                ).then(function (value) {
+                    resolvedValue = value;
+                });
+
+                return this.clock.tickAsync(0).then(function () {
+                    assert.equals(resolvedValue, "the first");
+                });
+            });
+        });
     });
 
     describe("clearImmediate", function () {
@@ -1087,7 +1090,7 @@ describe("FakeTimers", function () {
             assert.equals(stub.callCount, 1);
         });
 
-        it("is not influenced by forward system clock changes", function () {
+        it("is not influenced by forward system clock changes 2", function () {
             var clock = this.clock;
             var callback = function () {
                 clock.setSystemTime(new clock.Date().getTime() - 1000);
@@ -1118,7 +1121,7 @@ describe("FakeTimers", function () {
             assert.equals(stub.callCount, 1);
         });
 
-        it("is not influenced by forward system clock changes when an error is thrown", function () {
+        it("is not influenced by forward system clock changes when an error is thrown 2", function () {
             var clock = this.clock;
             var callback = function () {
                 clock.setSystemTime(new clock.Date().getTime() - 1000);
@@ -1147,692 +1150,686 @@ describe("FakeTimers", function () {
         });
     });
 
-    if (typeof global.Promise !== "undefined") {
-        describe("tickAsync", function () {
-            beforeEach(function () {
-                this.clock = FakeTimers.install();
-            });
-
-            afterEach(function () {
-                this.clock.uninstall();
-            });
-
-            it("triggers immediately without specified delay", function () {
-                var stub = sinon.stub();
-                this.clock.setTimeout(stub);
-
-                return this.clock.tickAsync(0).then(function () {
-                    assert(stub.called);
-                });
-            });
-
-            it("does not trigger without sufficient delay", function () {
-                var stub = sinon.stub();
-                this.clock.setTimeout(stub, 100);
-
-                return this.clock.tickAsync(10).then(function () {
-                    assert.isFalse(stub.called);
-                });
-            });
-
-            it("triggers after sufficient delay", function () {
-                var stub = sinon.stub();
-                this.clock.setTimeout(stub, 100);
-
-                return this.clock.tickAsync(100).then(function () {
-                    assert(stub.called);
-                });
-            });
-
-            it("triggers simultaneous timers", function () {
-                var spies = [sinon.spy(), sinon.spy()];
-                this.clock.setTimeout(spies[0], 100);
-                this.clock.setTimeout(spies[1], 100);
-
-                return this.clock.tickAsync(100).then(function () {
-                    assert(spies[0].called);
-                    assert(spies[1].called);
-                });
-            });
-
-            it("triggers multiple simultaneous timers", function () {
-                var spies = [
-                    sinon.spy(),
-                    sinon.spy(),
-                    sinon.spy(),
-                    sinon.spy(),
-                ];
-                this.clock.setTimeout(spies[0], 100);
-                this.clock.setTimeout(spies[1], 100);
-                this.clock.setTimeout(spies[2], 99);
-                this.clock.setTimeout(spies[3], 100);
-
-                return this.clock.tickAsync(100).then(function () {
-                    assert(spies[0].called);
-                    assert(spies[1].called);
-                    assert(spies[2].called);
-                    assert(spies[3].called);
-                });
-            });
-
-            it("triggers multiple simultaneous timers with zero callAt", function () {
-                var test = this;
-                var spies = [
-                    sinon.spy(function () {
-                        test.clock.setTimeout(spies[1], 0);
-                    }),
-                    sinon.spy(),
-                    sinon.spy(),
-                ];
-
-                // First spy calls another setTimeout with delay=0
-                this.clock.setTimeout(spies[0], 0);
-                this.clock.setTimeout(spies[2], 10);
-
-                return this.clock.tickAsync(10).then(function () {
-                    assert(spies[0].called);
-                    assert(spies[1].called);
-                    assert(spies[2].called);
-                });
-            });
-
-            it("triggers multiple simultaneous timers with zero callAt created in promises", function () {
-                var test = this;
-                var spies = [
-                    sinon.spy(function () {
-                        global.Promise.resolve().then(function () {
-                            test.clock.setTimeout(spies[1], 0);
-                        });
-                    }),
-                    sinon.spy(),
-                    sinon.spy(),
-                ];
-
-                // First spy calls another setTimeout with delay=0
-                this.clock.setTimeout(spies[0], 0);
-                this.clock.setTimeout(spies[2], 10);
-
-                return this.clock.tickAsync(10).then(function () {
-                    assert(spies[0].called);
-                    assert(spies[1].called);
-                    assert(spies[2].called);
-                });
-            });
-
-            it("waits after setTimeout was called", function () {
-                var clock = this.clock;
-                var stub = sinon.stub();
-
-                return clock
-                    .tickAsync(100)
-                    .then(function () {
-                        clock.setTimeout(stub, 150);
-                        return clock.tickAsync(50);
-                    })
-                    .then(function () {
-                        assert.isFalse(stub.called);
-                        return clock.tickAsync(100);
-                    })
-                    .then(function () {
-                        assert(stub.called);
-                    });
-            });
-
-            it("mini integration test", function () {
-                var clock = this.clock;
-                var stubs = [sinon.stub(), sinon.stub(), sinon.stub()];
-                clock.setTimeout(stubs[0], 100);
-                clock.setTimeout(stubs[1], 120);
-
-                return clock
-                    .tickAsync(10)
-                    .then(function () {
-                        return clock.tickAsync(89);
-                    })
-                    .then(function () {
-                        assert.isFalse(stubs[0].called);
-                        assert.isFalse(stubs[1].called);
-                        clock.setTimeout(stubs[2], 20);
-                        return clock.tickAsync(1);
-                    })
-                    .then(function () {
-                        assert(stubs[0].called);
-                        assert.isFalse(stubs[1].called);
-                        assert.isFalse(stubs[2].called);
-                        return clock.tickAsync(19);
-                    })
-                    .then(function () {
-                        assert.isFalse(stubs[1].called);
-                        assert(stubs[2].called);
-                        return clock.tickAsync(1);
-                    })
-                    .then(function () {
-                        assert(stubs[1].called);
-                    });
-            });
-
-            it("triggers even when some throw", function () {
-                var clock = this.clock;
-                var stubs = [sinon.stub().throws(), sinon.stub()];
-                var catchSpy = sinon.spy();
-
-                clock.setTimeout(stubs[0], 100);
-                clock.setTimeout(stubs[1], 120);
-
-                return clock
-                    .tickAsync(120)
-                    .catch(catchSpy)
-                    .then(function () {
-                        assert(catchSpy.calledOnce);
-                        assert(stubs[0].called);
-                        assert(stubs[1].called);
-                    });
-            });
-
-            it("calls function with global object or null (strict mode) as this", function () {
-                var clock = this.clock;
-                var stub = sinon.stub().throws();
-                var catchSpy = sinon.spy();
-                clock.setTimeout(stub, 100);
-
-                return clock
-                    .tickAsync(100)
-                    .catch(catchSpy)
-                    .then(function () {
-                        assert(catchSpy.calledOnce);
-                        assert(stub.calledOn(global) || stub.calledOn(null));
-                    });
-            });
-
-            it("triggers in the order scheduled", function () {
-                var spies = [sinon.spy(), sinon.spy()];
-                this.clock.setTimeout(spies[0], 13);
-                this.clock.setTimeout(spies[1], 11);
-
-                return this.clock.tickAsync(15).then(function () {
-                    assert(spies[1].calledBefore(spies[0]));
-                });
-            });
-
-            it("creates updated Date while ticking", function () {
-                var spy = sinon.spy();
-
-                this.clock.setInterval(function () {
-                    spy(new Date().getTime());
-                }, 10);
-
-                return this.clock.tickAsync(100).then(function () {
-                    assert.equals(spy.callCount, 10);
-                    assert(spy.calledWith(10));
-                    assert(spy.calledWith(20));
-                    assert(spy.calledWith(30));
-                    assert(spy.calledWith(40));
-                    assert(spy.calledWith(50));
-                    assert(spy.calledWith(60));
-                    assert(spy.calledWith(70));
-                    assert(spy.calledWith(80));
-                    assert(spy.calledWith(90));
-                    assert(spy.calledWith(100));
-                });
-            });
-
-            it("creates updated Date while ticking promises", function () {
-                var spy = sinon.spy();
-
-                this.clock.setInterval(function () {
-                    global.Promise.resolve().then(function () {
-                        spy(new Date().getTime());
-                    });
-                }, 10);
-
-                return this.clock.tickAsync(100).then(function () {
-                    assert.equals(spy.callCount, 10);
-                    assert(spy.calledWith(10));
-                    assert(spy.calledWith(20));
-                    assert(spy.calledWith(30));
-                    assert(spy.calledWith(40));
-                    assert(spy.calledWith(50));
-                    assert(spy.calledWith(60));
-                    assert(spy.calledWith(70));
-                    assert(spy.calledWith(80));
-                    assert(spy.calledWith(90));
-                    assert(spy.calledWith(100));
-                });
-            });
-
-            it("fires timer in intervals of 13", function () {
-                var spy = sinon.spy();
-                this.clock.setInterval(spy, 13);
-
-                return this.clock.tickAsync(500).then(function () {
-                    assert.equals(spy.callCount, 38);
-                });
-            });
-
-            it("fires timers in correct order", function () {
-                var spy13 = sinon.spy();
-                var spy10 = sinon.spy();
-
-                this.clock.setInterval(function () {
-                    spy13(new Date().getTime());
-                }, 13);
-
-                this.clock.setInterval(function () {
-                    spy10(new Date().getTime());
-                }, 10);
-
-                return this.clock.tickAsync(500).then(function () {
-                    assert.equals(spy13.callCount, 38);
-                    assert.equals(spy10.callCount, 50);
-
-                    assert(spy13.calledWith(416));
-                    assert(spy10.calledWith(320));
-
-                    assert(spy10.getCall(0).calledBefore(spy13.getCall(0)));
-                    assert(spy10.getCall(4).calledBefore(spy13.getCall(3)));
-                });
-            });
-
-            it("fires promise timers in correct order", function () {
-                var spy13 = sinon.spy();
-                var spy10 = sinon.spy();
-
-                this.clock.setInterval(function () {
-                    global.Promise.resolve().then(function () {
-                        spy13(new Date().getTime());
-                    });
-                }, 13);
-
-                this.clock.setInterval(function () {
-                    global.Promise.resolve().then(function () {
-                        spy10(new Date().getTime());
-                    });
-                }, 10);
-
-                return this.clock.tickAsync(500).then(function () {
-                    assert.equals(spy13.callCount, 38);
-                    assert.equals(spy10.callCount, 50);
-
-                    assert(spy13.calledWith(416));
-                    assert(spy10.calledWith(320));
-
-                    assert(spy10.getCall(0).calledBefore(spy13.getCall(0)));
-                    assert(spy10.getCall(4).calledBefore(spy13.getCall(3)));
-                });
-            });
-
-            it("triggers timeouts and intervals in the order scheduled", function () {
-                var spies = [sinon.spy(), sinon.spy()];
-                this.clock.setInterval(spies[0], 10);
-                this.clock.setTimeout(spies[1], 50);
-
-                return this.clock.tickAsync(100).then(function () {
-                    assert(spies[0].calledBefore(spies[1]));
-                    assert.equals(spies[0].callCount, 10);
-                    assert.equals(spies[1].callCount, 1);
-                });
-            });
-
-            it("does not fire canceled intervals", function () {
-                var id;
-                var callback = sinon.spy(function () {
-                    if (callback.callCount === 3) {
-                        clearInterval(id);
-                    }
-                });
-
-                id = this.clock.setInterval(callback, 10);
-                return this.clock.tickAsync(100).then(function () {
-                    assert.equals(callback.callCount, 3);
-                });
-            });
-
-            it("does not fire intervals canceled in a promise", function () {
-                var id;
-                var callback = sinon.spy(function () {
-                    if (callback.callCount === 3) {
-                        global.Promise.resolve().then(function () {
-                            clearInterval(id);
-                        });
-                    }
-                });
-
-                id = this.clock.setInterval(callback, 10);
-                return this.clock.tickAsync(100).then(function () {
-                    assert.equals(callback.callCount, 3);
-                });
-            });
-
-            it("passes 8 seconds", function () {
-                var spy = sinon.spy();
-                this.clock.setInterval(spy, 4000);
-
-                return this.clock.tickAsync("08").then(function () {
-                    assert.equals(spy.callCount, 2);
-                });
-            });
-
-            it("passes 1 minute", function () {
-                var spy = sinon.spy();
-                this.clock.setInterval(spy, 6000);
-
-                return this.clock.tickAsync("01:00").then(function () {
-                    assert.equals(spy.callCount, 10);
-                });
-            });
-
-            it("passes 2 hours, 34 minutes and 10 seconds", function () {
-                var spy = sinon.spy();
-                this.clock.setInterval(spy, 100000);
-
-                return this.clock.tickAsync("02:34:10").then(function () {
-                    assert.equals(spy.callCount, 92);
-                });
-            });
-
-            it("throws for invalid format", function () {
-                var spy = sinon.spy();
-                this.clock.setInterval(spy, 10000);
-                var test = this;
-                var catchSpy = sinon.spy();
-
-                return test.clock
-                    .tickAsync("12:02:34:10")
-                    .catch(catchSpy)
-                    .then(function () {
-                        assert(catchSpy.calledOnce);
-                        assert.equals(spy.callCount, 0);
-                    });
-            });
-
-            it("throws for invalid minutes", function () {
-                var spy = sinon.spy();
-                this.clock.setInterval(spy, 10000);
-                var test = this;
-                var catchSpy = sinon.spy();
-
-                return test.clock
-                    .tickAsync("67:10")
-                    .catch(catchSpy)
-                    .then(function () {
-                        assert(catchSpy.calledOnce);
-                        assert.equals(spy.callCount, 0);
-                    });
-            });
-
-            it("throws for negative minutes", function () {
-                var spy = sinon.spy();
-                this.clock.setInterval(spy, 10000);
-                var test = this;
-                var catchSpy = sinon.spy();
-
-                return test.clock
-                    .tickAsync("-7:10")
-                    .catch(catchSpy)
-                    .then(function () {
-                        assert(catchSpy.calledOnce);
-                        assert.equals(spy.callCount, 0);
-                    });
-            });
-
-            it("treats missing argument as 0", function () {
-                var clock = this.clock;
-                return this.clock.tickAsync().then(function () {
-                    assert.equals(clock.now, 0);
-                });
-            });
-
-            it("fires nested setTimeout calls properly", function () {
-                var i = 0;
-                var clock = this.clock;
-
-                var callback = function () {
-                    ++i;
-                    clock.setTimeout(function () {
-                        callback();
-                    }, 100);
-                };
-
-                callback();
-
-                return clock.tickAsync(1000).then(function () {
-                    assert.equals(i, 11);
-                });
-            });
-
-            it("fires nested setTimeout calls in user-created promises properly", function () {
-                var i = 0;
-                var clock = this.clock;
-
-                var callback = function () {
-                    global.Promise.resolve().then(function () {
-                        ++i;
-                        clock.setTimeout(function () {
-                            global.Promise.resolve().then(function () {
-                                callback();
-                            });
-                        }, 100);
-                    });
-                };
-
-                callback();
-
-                return clock.tickAsync(1000).then(function () {
-                    assert.equals(i, 11);
-                });
-            });
-
-            it("does not silently catch errors", function () {
-                var clock = this.clock;
-                var catchSpy = sinon.spy();
-
-                clock.setTimeout(function () {
-                    throw new Error("oh no!");
-                }, 1000);
-
-                return clock
-                    .tickAsync(1000)
-                    .catch(catchSpy)
-                    .then(function () {
-                        assert(catchSpy.calledOnce);
-                    });
-            });
-
-            it("returns the current now value", function () {
-                var clock = this.clock;
-                return clock.tickAsync(200).then(function (value) {
-                    assert.equals(clock.now, value);
-                });
-            });
-
-            it("is not influenced by forward system clock changes", function () {
-                var clock = this.clock;
-                var callback = function () {
-                    clock.setSystemTime(new clock.Date().getTime() + 1000);
-                };
-                var stub = sinon.stub();
-                clock.setTimeout(callback, 1000);
-                clock.setTimeout(stub, 2000);
-                return clock
-                    .tickAsync(1990)
-                    .then(function () {
-                        assert.equals(stub.callCount, 0);
-                        return clock.tickAsync(20);
-                    })
-                    .then(function () {
-                        assert.equals(stub.callCount, 1);
-                    });
-            });
-
-            it("is not influenced by forward system clock changes in promises", function () {
-                var clock = this.clock;
-                var callback = function () {
-                    global.Promise.resolve().then(function () {
-                        clock.setSystemTime(new clock.Date().getTime() + 1000);
-                    });
-                };
-                var stub = sinon.stub();
-                clock.setTimeout(callback, 1000);
-                clock.setTimeout(stub, 2000);
-                return clock
-                    .tickAsync(1990)
-                    .then(function () {
-                        assert.equals(stub.callCount, 0);
-                        return clock.tickAsync(20);
-                    })
-                    .then(function () {
-                        assert.equals(stub.callCount, 1);
-                    });
-            });
-
-            it("is not influenced by forward system clock changes when an error is thrown", function () {
-                var clock = this.clock;
-                var callback = function () {
-                    clock.setSystemTime(new clock.Date().getTime() + 1000);
-                    throw new Error();
-                };
-                var stub = sinon.stub();
-                var catchSpy = sinon.spy();
-                clock.setTimeout(callback, 1000);
-                clock.setTimeout(stub, 2000);
-                return clock
-                    .tickAsync(1990)
-                    .catch(catchSpy)
-                    .then(function () {
-                        assert(catchSpy.calledOnce);
-                        assert.equals(stub.callCount, 0);
-                        return clock.tickAsync(20);
-                    })
-                    .then(function () {
-                        assert.equals(stub.callCount, 1);
-                    });
-            });
-
-            it("should settle user-created promises", function () {
-                var spy = sinon.spy();
-
-                setTimeout(function () {
-                    global.Promise.resolve().then(spy);
-                }, 100);
-
-                return this.clock.tickAsync(100).then(function () {
-                    assert(spy.calledOnce);
-                });
-            });
-
-            it("should settle chained user-created promises", function () {
-                var spies = [sinon.spy(), sinon.spy(), sinon.spy()];
-
-                setTimeout(function () {
-                    global.Promise.resolve()
-                        .then(spies[0])
-                        .then(spies[1])
-                        .then(spies[2]);
-                }, 100);
-
-                return this.clock.tickAsync(100).then(function () {
-                    assert(spies[0].calledOnce);
-                    assert(spies[1].calledOnce);
-                    assert(spies[2].calledOnce);
-                });
-            });
-
-            it("should settle multiple user-created promises", function () {
-                var spies = [sinon.spy(), sinon.spy(), sinon.spy()];
-
-                setTimeout(function () {
-                    global.Promise.resolve().then(spies[0]);
-                    global.Promise.resolve().then(spies[1]);
-                    global.Promise.resolve().then(spies[2]);
-                }, 100);
-
-                return this.clock.tickAsync(100).then(function () {
-                    assert(spies[0].calledOnce);
-                    assert(spies[1].calledOnce);
-                    assert(spies[2].calledOnce);
-                });
-            });
-
-            it("should settle nested user-created promises", function () {
-                var spy = sinon.spy();
-
-                setTimeout(function () {
-                    global.Promise.resolve().then(function () {
-                        global.Promise.resolve().then(function () {
-                            global.Promise.resolve().then(spy);
-                        });
-                    });
-                }, 100);
-
-                return this.clock.tickAsync(100).then(function () {
-                    assert(spy.calledOnce);
-                });
-            });
-
-            it("should settle user-created promises even if some throw", function () {
-                var spies = [
-                    sinon.spy(),
-                    sinon.spy(),
-                    sinon.spy(),
-                    sinon.spy(),
-                ];
-
-                setTimeout(function () {
-                    global.Promise.reject().then(spies[0]).catch(spies[1]);
-                    global.Promise.resolve().then(spies[2]).catch(spies[3]);
-                }, 100);
-
-                return this.clock.tickAsync(100).then(function () {
-                    assert(spies[0].notCalled);
-                    assert(spies[1].calledOnce);
-                    assert(spies[2].calledOnce);
-                    assert(spies[3].notCalled);
-                });
-            });
-
-            it("should settle user-created promises before calling more timeouts", function () {
-                var spies = [sinon.spy(), sinon.spy()];
-
-                setTimeout(function () {
-                    global.Promise.resolve().then(spies[0]);
-                }, 100);
-
-                setTimeout(spies[1], 200);
-
-                return this.clock.tickAsync(200).then(function () {
-                    assert(spies[0].calledBefore(spies[1]));
-                });
-            });
-
-            it("should settle local promises before calling timeouts", function () {
-                var spies = [sinon.spy(), sinon.spy()];
-
-                global.Promise.resolve().then(spies[0]);
-
-                setTimeout(spies[1], 100);
-
-                return this.clock.tickAsync(100).then(function () {
-                    assert(spies[0].calledBefore(spies[1]));
-                });
-            });
-
-            it("should settle local nested promises before calling timeouts", function () {
-                var spies = [sinon.spy(), sinon.spy()];
-
-                global.Promise.resolve().then(function () {
-                    global.Promise.resolve().then(function () {
-                        global.Promise.resolve().then(spies[0]);
-                    });
-                });
-
-                setTimeout(spies[1], 100);
-
-                return this.clock.tickAsync(100).then(function () {
-                    assert(spies[0].calledBefore(spies[1]));
-                });
+    describe("tickAsync", function () {
+        before(function () {
+            if (!promisePresent) {
+                this.skip();
+            }
+        });
+
+        beforeEach(function () {
+            this.clock = FakeTimers.install();
+        });
+
+        afterEach(function () {
+            this.clock.uninstall();
+        });
+
+        it("triggers immediately without specified delay", function () {
+            var stub = sinon.stub();
+            this.clock.setTimeout(stub);
+
+            return this.clock.tickAsync(0).then(function () {
+                assert(stub.called);
             });
         });
-    }
+
+        it("does not trigger without sufficient delay", function () {
+            var stub = sinon.stub();
+            this.clock.setTimeout(stub, 100);
+
+            return this.clock.tickAsync(10).then(function () {
+                assert.isFalse(stub.called);
+            });
+        });
+
+        it("triggers after sufficient delay", function () {
+            var stub = sinon.stub();
+            this.clock.setTimeout(stub, 100);
+
+            return this.clock.tickAsync(100).then(function () {
+                assert(stub.called);
+            });
+        });
+
+        it("triggers simultaneous timers", function () {
+            var spies = [sinon.spy(), sinon.spy()];
+            this.clock.setTimeout(spies[0], 100);
+            this.clock.setTimeout(spies[1], 100);
+
+            return this.clock.tickAsync(100).then(function () {
+                assert(spies[0].called);
+                assert(spies[1].called);
+            });
+        });
+
+        it("triggers multiple simultaneous timers", function () {
+            var spies = [sinon.spy(), sinon.spy(), sinon.spy(), sinon.spy()];
+            this.clock.setTimeout(spies[0], 100);
+            this.clock.setTimeout(spies[1], 100);
+            this.clock.setTimeout(spies[2], 99);
+            this.clock.setTimeout(spies[3], 100);
+
+            return this.clock.tickAsync(100).then(function () {
+                assert(spies[0].called);
+                assert(spies[1].called);
+                assert(spies[2].called);
+                assert(spies[3].called);
+            });
+        });
+
+        it("triggers multiple simultaneous timers with zero callAt", function () {
+            var test = this;
+            var spies = [
+                sinon.spy(function () {
+                    test.clock.setTimeout(spies[1], 0);
+                }),
+                sinon.spy(),
+                sinon.spy(),
+            ];
+
+            // First spy calls another setTimeout with delay=0
+            this.clock.setTimeout(spies[0], 0);
+            this.clock.setTimeout(spies[2], 10);
+
+            return this.clock.tickAsync(10).then(function () {
+                assert(spies[0].called);
+                assert(spies[1].called);
+                assert(spies[2].called);
+            });
+        });
+
+        it("triggers multiple simultaneous timers with zero callAt created in promises", function () {
+            var test = this;
+            var spies = [
+                sinon.spy(function () {
+                    global.Promise.resolve().then(function () {
+                        test.clock.setTimeout(spies[1], 0);
+                    });
+                }),
+                sinon.spy(),
+                sinon.spy(),
+            ];
+
+            // First spy calls another setTimeout with delay=0
+            this.clock.setTimeout(spies[0], 0);
+            this.clock.setTimeout(spies[2], 10);
+
+            return this.clock.tickAsync(10).then(function () {
+                assert(spies[0].called);
+                assert(spies[1].called);
+                assert(spies[2].called);
+            });
+        });
+
+        it("waits after setTimeout was called", function () {
+            var clock = this.clock;
+            var stub = sinon.stub();
+
+            return clock
+                .tickAsync(100)
+                .then(function () {
+                    clock.setTimeout(stub, 150);
+                    return clock.tickAsync(50);
+                })
+                .then(function () {
+                    assert.isFalse(stub.called);
+                    return clock.tickAsync(100);
+                })
+                .then(function () {
+                    assert(stub.called);
+                });
+        });
+
+        it("mini integration test", function () {
+            var clock = this.clock;
+            var stubs = [sinon.stub(), sinon.stub(), sinon.stub()];
+            clock.setTimeout(stubs[0], 100);
+            clock.setTimeout(stubs[1], 120);
+
+            return clock
+                .tickAsync(10)
+                .then(function () {
+                    return clock.tickAsync(89);
+                })
+                .then(function () {
+                    assert.isFalse(stubs[0].called);
+                    assert.isFalse(stubs[1].called);
+                    clock.setTimeout(stubs[2], 20);
+                    return clock.tickAsync(1);
+                })
+                .then(function () {
+                    assert(stubs[0].called);
+                    assert.isFalse(stubs[1].called);
+                    assert.isFalse(stubs[2].called);
+                    return clock.tickAsync(19);
+                })
+                .then(function () {
+                    assert.isFalse(stubs[1].called);
+                    assert(stubs[2].called);
+                    return clock.tickAsync(1);
+                })
+                .then(function () {
+                    assert(stubs[1].called);
+                });
+        });
+
+        it("triggers even when some throw", function () {
+            var clock = this.clock;
+            var stubs = [sinon.stub().throws(), sinon.stub()];
+            var catchSpy = sinon.spy();
+
+            clock.setTimeout(stubs[0], 100);
+            clock.setTimeout(stubs[1], 120);
+
+            return clock
+                .tickAsync(120)
+                .catch(catchSpy)
+                .then(function () {
+                    assert(catchSpy.calledOnce);
+                    assert(stubs[0].called);
+                    assert(stubs[1].called);
+                });
+        });
+
+        it("calls function with global object or null (strict mode) as this", function () {
+            var clock = this.clock;
+            var stub = sinon.stub().throws();
+            var catchSpy = sinon.spy();
+            clock.setTimeout(stub, 100);
+
+            return clock
+                .tickAsync(100)
+                .catch(catchSpy)
+                .then(function () {
+                    assert(catchSpy.calledOnce);
+                    assert(stub.calledOn(global) || stub.calledOn(null));
+                });
+        });
+
+        it("triggers in the order scheduled", function () {
+            var spies = [sinon.spy(), sinon.spy()];
+            this.clock.setTimeout(spies[0], 13);
+            this.clock.setTimeout(spies[1], 11);
+
+            return this.clock.tickAsync(15).then(function () {
+                assert(spies[1].calledBefore(spies[0]));
+            });
+        });
+
+        it("creates updated Date while ticking", function () {
+            var spy = sinon.spy();
+
+            this.clock.setInterval(function () {
+                spy(new Date().getTime());
+            }, 10);
+
+            return this.clock.tickAsync(100).then(function () {
+                assert.equals(spy.callCount, 10);
+                assert(spy.calledWith(10));
+                assert(spy.calledWith(20));
+                assert(spy.calledWith(30));
+                assert(spy.calledWith(40));
+                assert(spy.calledWith(50));
+                assert(spy.calledWith(60));
+                assert(spy.calledWith(70));
+                assert(spy.calledWith(80));
+                assert(spy.calledWith(90));
+                assert(spy.calledWith(100));
+            });
+        });
+
+        it("creates updated Date while ticking promises", function () {
+            var spy = sinon.spy();
+
+            this.clock.setInterval(function () {
+                global.Promise.resolve().then(function () {
+                    spy(new Date().getTime());
+                });
+            }, 10);
+
+            return this.clock.tickAsync(100).then(function () {
+                assert.equals(spy.callCount, 10);
+                assert(spy.calledWith(10));
+                assert(spy.calledWith(20));
+                assert(spy.calledWith(30));
+                assert(spy.calledWith(40));
+                assert(spy.calledWith(50));
+                assert(spy.calledWith(60));
+                assert(spy.calledWith(70));
+                assert(spy.calledWith(80));
+                assert(spy.calledWith(90));
+                assert(spy.calledWith(100));
+            });
+        });
+
+        it("fires timer in intervals of 13", function () {
+            var spy = sinon.spy();
+            this.clock.setInterval(spy, 13);
+
+            return this.clock.tickAsync(500).then(function () {
+                assert.equals(spy.callCount, 38);
+            });
+        });
+
+        it("fires timers in correct order", function () {
+            var spy13 = sinon.spy();
+            var spy10 = sinon.spy();
+
+            this.clock.setInterval(function () {
+                spy13(new Date().getTime());
+            }, 13);
+
+            this.clock.setInterval(function () {
+                spy10(new Date().getTime());
+            }, 10);
+
+            return this.clock.tickAsync(500).then(function () {
+                assert.equals(spy13.callCount, 38);
+                assert.equals(spy10.callCount, 50);
+
+                assert(spy13.calledWith(416));
+                assert(spy10.calledWith(320));
+
+                assert(spy10.getCall(0).calledBefore(spy13.getCall(0)));
+                assert(spy10.getCall(4).calledBefore(spy13.getCall(3)));
+            });
+        });
+
+        it("fires promise timers in correct order", function () {
+            var spy13 = sinon.spy();
+            var spy10 = sinon.spy();
+
+            this.clock.setInterval(function () {
+                global.Promise.resolve().then(function () {
+                    spy13(new Date().getTime());
+                });
+            }, 13);
+
+            this.clock.setInterval(function () {
+                global.Promise.resolve().then(function () {
+                    spy10(new Date().getTime());
+                });
+            }, 10);
+
+            return this.clock.tickAsync(500).then(function () {
+                assert.equals(spy13.callCount, 38);
+                assert.equals(spy10.callCount, 50);
+
+                assert(spy13.calledWith(416));
+                assert(spy10.calledWith(320));
+
+                assert(spy10.getCall(0).calledBefore(spy13.getCall(0)));
+                assert(spy10.getCall(4).calledBefore(spy13.getCall(3)));
+            });
+        });
+
+        it("triggers timeouts and intervals in the order scheduled", function () {
+            var spies = [sinon.spy(), sinon.spy()];
+            this.clock.setInterval(spies[0], 10);
+            this.clock.setTimeout(spies[1], 50);
+
+            return this.clock.tickAsync(100).then(function () {
+                assert(spies[0].calledBefore(spies[1]));
+                assert.equals(spies[0].callCount, 10);
+                assert.equals(spies[1].callCount, 1);
+            });
+        });
+
+        it("does not fire canceled intervals", function () {
+            var id;
+            var callback = sinon.spy(function () {
+                if (callback.callCount === 3) {
+                    clearInterval(id);
+                }
+            });
+
+            id = this.clock.setInterval(callback, 10);
+            return this.clock.tickAsync(100).then(function () {
+                assert.equals(callback.callCount, 3);
+            });
+        });
+
+        it("does not fire intervals canceled in a promise", function () {
+            var id;
+            var callback = sinon.spy(function () {
+                if (callback.callCount === 3) {
+                    global.Promise.resolve().then(function () {
+                        clearInterval(id);
+                    });
+                }
+            });
+
+            id = this.clock.setInterval(callback, 10);
+            return this.clock.tickAsync(100).then(function () {
+                assert.equals(callback.callCount, 3);
+            });
+        });
+
+        it("passes 8 seconds", function () {
+            var spy = sinon.spy();
+            this.clock.setInterval(spy, 4000);
+
+            return this.clock.tickAsync("08").then(function () {
+                assert.equals(spy.callCount, 2);
+            });
+        });
+
+        it("passes 1 minute", function () {
+            var spy = sinon.spy();
+            this.clock.setInterval(spy, 6000);
+
+            return this.clock.tickAsync("01:00").then(function () {
+                assert.equals(spy.callCount, 10);
+            });
+        });
+
+        it("passes 2 hours, 34 minutes and 10 seconds", function () {
+            var spy = sinon.spy();
+            this.clock.setInterval(spy, 100000);
+
+            return this.clock.tickAsync("02:34:10").then(function () {
+                assert.equals(spy.callCount, 92);
+            });
+        });
+
+        it("throws for invalid format", function () {
+            var spy = sinon.spy();
+            this.clock.setInterval(spy, 10000);
+            var test = this;
+            var catchSpy = sinon.spy();
+
+            return test.clock
+                .tickAsync("12:02:34:10")
+                .catch(catchSpy)
+                .then(function () {
+                    assert(catchSpy.calledOnce);
+                    assert.equals(spy.callCount, 0);
+                });
+        });
+
+        it("throws for invalid minutes", function () {
+            var spy = sinon.spy();
+            this.clock.setInterval(spy, 10000);
+            var test = this;
+            var catchSpy = sinon.spy();
+
+            return test.clock
+                .tickAsync("67:10")
+                .catch(catchSpy)
+                .then(function () {
+                    assert(catchSpy.calledOnce);
+                    assert.equals(spy.callCount, 0);
+                });
+        });
+
+        it("throws for negative minutes", function () {
+            var spy = sinon.spy();
+            this.clock.setInterval(spy, 10000);
+            var test = this;
+            var catchSpy = sinon.spy();
+
+            return test.clock
+                .tickAsync("-7:10")
+                .catch(catchSpy)
+                .then(function () {
+                    assert(catchSpy.calledOnce);
+                    assert.equals(spy.callCount, 0);
+                });
+        });
+
+        it("treats missing argument as 0", function () {
+            var clock = this.clock;
+            return this.clock.tickAsync().then(function () {
+                assert.equals(clock.now, 0);
+            });
+        });
+
+        it("fires nested setTimeout calls properly", function () {
+            var i = 0;
+            var clock = this.clock;
+
+            var callback = function () {
+                ++i;
+                clock.setTimeout(function () {
+                    callback();
+                }, 100);
+            };
+
+            callback();
+
+            return clock.tickAsync(1000).then(function () {
+                assert.equals(i, 11);
+            });
+        });
+
+        it("fires nested setTimeout calls in user-created promises properly", function () {
+            var i = 0;
+            var clock = this.clock;
+
+            var callback = function () {
+                global.Promise.resolve().then(function () {
+                    ++i;
+                    clock.setTimeout(function () {
+                        global.Promise.resolve().then(function () {
+                            callback();
+                        });
+                    }, 100);
+                });
+            };
+
+            callback();
+
+            return clock.tickAsync(1000).then(function () {
+                assert.equals(i, 11);
+            });
+        });
+
+        it("does not silently catch errors", function () {
+            var clock = this.clock;
+            var catchSpy = sinon.spy();
+
+            clock.setTimeout(function () {
+                throw new Error("oh no!");
+            }, 1000);
+
+            return clock
+                .tickAsync(1000)
+                .catch(catchSpy)
+                .then(function () {
+                    assert(catchSpy.calledOnce);
+                });
+        });
+
+        it("returns the current now value", function () {
+            var clock = this.clock;
+            return clock.tickAsync(200).then(function (value) {
+                assert.equals(clock.now, value);
+            });
+        });
+
+        it("is not influenced by forward system clock changes", function () {
+            var clock = this.clock;
+            var callback = function () {
+                clock.setSystemTime(new clock.Date().getTime() + 1000);
+            };
+            var stub = sinon.stub();
+            clock.setTimeout(callback, 1000);
+            clock.setTimeout(stub, 2000);
+            return clock
+                .tickAsync(1990)
+                .then(function () {
+                    assert.equals(stub.callCount, 0);
+                    return clock.tickAsync(20);
+                })
+                .then(function () {
+                    assert.equals(stub.callCount, 1);
+                });
+        });
+
+        it("is not influenced by forward system clock changes in promises", function () {
+            var clock = this.clock;
+            var callback = function () {
+                global.Promise.resolve().then(function () {
+                    clock.setSystemTime(new clock.Date().getTime() + 1000);
+                });
+            };
+            var stub = sinon.stub();
+            clock.setTimeout(callback, 1000);
+            clock.setTimeout(stub, 2000);
+            return clock
+                .tickAsync(1990)
+                .then(function () {
+                    assert.equals(stub.callCount, 0);
+                    return clock.tickAsync(20);
+                })
+                .then(function () {
+                    assert.equals(stub.callCount, 1);
+                });
+        });
+
+        it("is not influenced by forward system clock changes when an error is thrown", function () {
+            var clock = this.clock;
+            var callback = function () {
+                clock.setSystemTime(new clock.Date().getTime() + 1000);
+                throw new Error();
+            };
+            var stub = sinon.stub();
+            var catchSpy = sinon.spy();
+            clock.setTimeout(callback, 1000);
+            clock.setTimeout(stub, 2000);
+            return clock
+                .tickAsync(1990)
+                .catch(catchSpy)
+                .then(function () {
+                    assert(catchSpy.calledOnce);
+                    assert.equals(stub.callCount, 0);
+                    return clock.tickAsync(20);
+                })
+                .then(function () {
+                    assert.equals(stub.callCount, 1);
+                });
+        });
+
+        it("should settle user-created promises", function () {
+            var spy = sinon.spy();
+
+            setTimeout(function () {
+                global.Promise.resolve().then(spy);
+            }, 100);
+
+            return this.clock.tickAsync(100).then(function () {
+                assert(spy.calledOnce);
+            });
+        });
+
+        it("should settle chained user-created promises", function () {
+            var spies = [sinon.spy(), sinon.spy(), sinon.spy()];
+
+            setTimeout(function () {
+                global.Promise.resolve()
+                    .then(spies[0])
+                    .then(spies[1])
+                    .then(spies[2]);
+            }, 100);
+
+            return this.clock.tickAsync(100).then(function () {
+                assert(spies[0].calledOnce);
+                assert(spies[1].calledOnce);
+                assert(spies[2].calledOnce);
+            });
+        });
+
+        it("should settle multiple user-created promises", function () {
+            var spies = [sinon.spy(), sinon.spy(), sinon.spy()];
+
+            setTimeout(function () {
+                global.Promise.resolve().then(spies[0]);
+                global.Promise.resolve().then(spies[1]);
+                global.Promise.resolve().then(spies[2]);
+            }, 100);
+
+            return this.clock.tickAsync(100).then(function () {
+                assert(spies[0].calledOnce);
+                assert(spies[1].calledOnce);
+                assert(spies[2].calledOnce);
+            });
+        });
+
+        it("should settle nested user-created promises", function () {
+            var spy = sinon.spy();
+
+            setTimeout(function () {
+                global.Promise.resolve().then(function () {
+                    global.Promise.resolve().then(function () {
+                        global.Promise.resolve().then(spy);
+                    });
+                });
+            }, 100);
+
+            return this.clock.tickAsync(100).then(function () {
+                assert(spy.calledOnce);
+            });
+        });
+
+        it("should settle user-created promises even if some throw", function () {
+            var spies = [sinon.spy(), sinon.spy(), sinon.spy(), sinon.spy()];
+
+            setTimeout(function () {
+                global.Promise.reject().then(spies[0]).catch(spies[1]);
+                global.Promise.resolve().then(spies[2]).catch(spies[3]);
+            }, 100);
+
+            return this.clock.tickAsync(100).then(function () {
+                assert(spies[0].notCalled);
+                assert(spies[1].calledOnce);
+                assert(spies[2].calledOnce);
+                assert(spies[3].notCalled);
+            });
+        });
+
+        it("should settle user-created promises before calling more timeouts", function () {
+            var spies = [sinon.spy(), sinon.spy()];
+
+            setTimeout(function () {
+                global.Promise.resolve().then(spies[0]);
+            }, 100);
+
+            setTimeout(spies[1], 200);
+
+            return this.clock.tickAsync(200).then(function () {
+                assert(spies[0].calledBefore(spies[1]));
+            });
+        });
+
+        it("should settle local promises before calling timeouts", function () {
+            var spies = [sinon.spy(), sinon.spy()];
+
+            global.Promise.resolve().then(spies[0]);
+
+            setTimeout(spies[1], 100);
+
+            return this.clock.tickAsync(100).then(function () {
+                assert(spies[0].calledBefore(spies[1]));
+            });
+        });
+
+        it("should settle local nested promises before calling timeouts", function () {
+            var spies = [sinon.spy(), sinon.spy()];
+
+            global.Promise.resolve().then(function () {
+                global.Promise.resolve().then(function () {
+                    global.Promise.resolve().then(spies[0]);
+                });
+            });
+
+            setTimeout(spies[1], 100);
+
+            return this.clock.tickAsync(100).then(function () {
+                assert(spies[0].calledBefore(spies[1]));
+            });
+        });
+    });
 
     describe("next", function () {
         beforeEach(function () {
@@ -2030,380 +2027,379 @@ describe("FakeTimers", function () {
         });
     });
 
-    if (typeof global.Promise !== "undefined") {
-        describe("nextAsync", function () {
-            beforeEach(function () {
-                this.clock = FakeTimers.install();
-            });
+    describe("nextAsync", function () {
+        before(function () {
+            if (!promisePresent) {
+                this.skip();
+            }
+        });
 
-            afterEach(function () {
-                this.clock.uninstall();
-            });
+        beforeEach(function () {
+            this.clock = FakeTimers.install();
+        });
 
-            it("triggers the next timer", function () {
-                var stub = sinon.stub();
-                this.clock.setTimeout(stub, 100);
+        afterEach(function () {
+            this.clock.uninstall();
+        });
 
-                return this.clock.nextAsync().then(function () {
-                    assert(stub.called);
-                });
-            });
+        it("triggers the next timer", function () {
+            var stub = sinon.stub();
+            this.clock.setTimeout(stub, 100);
 
-            it("does not trigger simultaneous timers", function () {
-                var spies = [sinon.spy(), sinon.spy()];
-                this.clock.setTimeout(spies[0], 100);
-                this.clock.setTimeout(spies[1], 100);
-
-                return this.clock.nextAsync().then(function () {
-                    assert(spies[0].called);
-                    assert.isFalse(spies[1].called);
-                });
-            });
-
-            it("subsequent calls trigger simultaneous timers", function () {
-                var spies = [
-                    sinon.spy(),
-                    sinon.spy(),
-                    sinon.spy(),
-                    sinon.spy(),
-                ];
-                var clock = this.clock;
-                this.clock.setTimeout(spies[0], 100);
-                this.clock.setTimeout(spies[1], 100);
-                this.clock.setTimeout(spies[2], 99);
-                this.clock.setTimeout(spies[3], 100);
-
-                return this.clock
-                    .nextAsync()
-                    .then(function () {
-                        assert(spies[2].called);
-                        assert.isFalse(spies[0].called);
-                        assert.isFalse(spies[1].called);
-                        assert.isFalse(spies[3].called);
-                        return clock.nextAsync();
-                    })
-                    .then(function () {
-                        assert(spies[0].called);
-                        assert.isFalse(spies[1].called);
-                        assert.isFalse(spies[3].called);
-
-                        return clock.nextAsync();
-                    })
-                    .then(function () {
-                        assert(spies[1].called);
-                        assert.isFalse(spies[3].called);
-
-                        return clock.nextAsync();
-                    })
-                    .then(function () {
-                        assert(spies[3].called);
-                    });
-            });
-
-            it("subsequent calls triggers simultaneous timers with zero callAt", function () {
-                var test = this;
-                var spies = [
-                    sinon.spy(function () {
-                        test.clock.setTimeout(spies[1], 0);
-                    }),
-                    sinon.spy(),
-                    sinon.spy(),
-                ];
-
-                // First spy calls another setTimeout with delay=0
-                this.clock.setTimeout(spies[0], 0);
-                this.clock.setTimeout(spies[2], 10);
-
-                return this.clock
-                    .nextAsync()
-                    .then(function () {
-                        assert(spies[0].called);
-                        assert.isFalse(spies[1].called);
-
-                        return test.clock.nextAsync();
-                    })
-                    .then(function () {
-                        assert(spies[1].called);
-
-                        return test.clock.nextAsync();
-                    })
-                    .then(function () {
-                        assert(spies[2].called);
-                    });
-            });
-
-            it("subsequent calls in promises triggers simultaneous timers with zero callAt", function () {
-                var test = this;
-                var spies = [
-                    sinon.spy(function () {
-                        global.Promise.resolve().then(function () {
-                            test.clock.setTimeout(spies[1], 0);
-                        });
-                    }),
-                    sinon.spy(),
-                    sinon.spy(),
-                ];
-
-                // First spy calls another setTimeout with delay=0
-                this.clock.setTimeout(spies[0], 0);
-                this.clock.setTimeout(spies[2], 10);
-
-                return this.clock
-                    .nextAsync()
-                    .then(function () {
-                        assert(spies[0].called);
-                        assert.isFalse(spies[1].called);
-
-                        return test.clock.nextAsync();
-                    })
-                    .then(function () {
-                        assert(spies[1].called);
-
-                        return test.clock.nextAsync();
-                    })
-                    .then(function () {
-                        assert(spies[2].called);
-                    });
-            });
-
-            it("throws exception thrown by timer", function () {
-                var clock = this.clock;
-                var stub = sinon.stub().throws();
-                var catchSpy = sinon.spy();
-
-                clock.setTimeout(stub, 100);
-
-                return clock
-                    .nextAsync()
-                    .catch(catchSpy)
-                    .then(function () {
-                        assert(catchSpy.calledOnce);
-
-                        assert(stub.called);
-                    });
-            });
-
-            it("calls function with global object or null (strict mode) as this", function () {
-                var clock = this.clock;
-                var stub = sinon.stub().throws();
-                var catchSpy = sinon.spy();
-                clock.setTimeout(stub, 100);
-
-                return clock
-                    .nextAsync()
-                    .catch(catchSpy)
-                    .then(function () {
-                        assert(catchSpy.calledOnce);
-
-                        assert(stub.calledOn(global) || stub.calledOn(null));
-                    });
-            });
-
-            it("subsequent calls trigger in the order scheduled", function () {
-                var clock = this.clock;
-                var spies = [sinon.spy(), sinon.spy()];
-                this.clock.setTimeout(spies[0], 13);
-                this.clock.setTimeout(spies[1], 11);
-
-                return this.clock
-                    .nextAsync()
-                    .then(function () {
-                        return clock.nextAsync();
-                    })
-                    .then(function () {
-                        assert(spies[1].calledBefore(spies[0]));
-                    });
-            });
-
-            it("subsequent calls create updated Date", function () {
-                var clock = this.clock;
-                var spy = sinon.spy();
-
-                this.clock.setInterval(function () {
-                    spy(new Date().getTime());
-                }, 10);
-
-                return this.clock
-                    .nextAsync()
-                    .then(clock.nextAsync)
-                    .then(clock.nextAsync)
-                    .then(clock.nextAsync)
-                    .then(clock.nextAsync)
-                    .then(clock.nextAsync)
-                    .then(clock.nextAsync)
-                    .then(clock.nextAsync)
-                    .then(clock.nextAsync)
-                    .then(clock.nextAsync)
-                    .then(function () {
-                        assert.equals(spy.callCount, 10);
-                        assert(spy.calledWith(10));
-                        assert(spy.calledWith(20));
-                        assert(spy.calledWith(30));
-                        assert(spy.calledWith(40));
-                        assert(spy.calledWith(50));
-                        assert(spy.calledWith(60));
-                        assert(spy.calledWith(70));
-                        assert(spy.calledWith(80));
-                        assert(spy.calledWith(90));
-                        assert(spy.calledWith(100));
-                    });
-            });
-
-            it("subsequent calls in promises create updated Date", function () {
-                var clock = this.clock;
-                var spy = sinon.spy();
-
-                this.clock.setInterval(function () {
-                    global.Promise.resolve().then(function () {
-                        spy(new Date().getTime());
-                    });
-                }, 10);
-
-                return this.clock
-                    .nextAsync()
-                    .then(clock.nextAsync)
-                    .then(clock.nextAsync)
-                    .then(clock.nextAsync)
-                    .then(clock.nextAsync)
-                    .then(clock.nextAsync)
-                    .then(clock.nextAsync)
-                    .then(clock.nextAsync)
-                    .then(clock.nextAsync)
-                    .then(clock.nextAsync)
-                    .then(function () {
-                        assert.equals(spy.callCount, 10);
-                        assert(spy.calledWith(10));
-                        assert(spy.calledWith(20));
-                        assert(spy.calledWith(30));
-                        assert(spy.calledWith(40));
-                        assert(spy.calledWith(50));
-                        assert(spy.calledWith(60));
-                        assert(spy.calledWith(70));
-                        assert(spy.calledWith(80));
-                        assert(spy.calledWith(90));
-                        assert(spy.calledWith(100));
-                    });
-            });
-
-            it("subsequent calls trigger timeouts and intervals in the order scheduled", function () {
-                var clock = this.clock;
-                var spies = [sinon.spy(), sinon.spy()];
-                this.clock.setInterval(spies[0], 10);
-                this.clock.setTimeout(spies[1], 50);
-
-                return this.clock
-                    .nextAsync()
-                    .then(clock.nextAsync)
-                    .then(clock.nextAsync)
-                    .then(clock.nextAsync)
-                    .then(clock.nextAsync)
-                    .then(clock.nextAsync)
-                    .then(function () {
-                        assert(spies[0].calledBefore(spies[1]));
-                        assert.equals(spies[0].callCount, 5);
-                        assert.equals(spies[1].callCount, 1);
-                    });
-            });
-
-            it("subsequent calls do not fire canceled intervals", function () {
-                var id;
-                var clock = this.clock;
-                var callback = sinon.spy(function () {
-                    if (callback.callCount === 3) {
-                        clearInterval(id);
-                    }
-                });
-
-                id = this.clock.setInterval(callback, 10);
-                return this.clock
-                    .nextAsync()
-                    .then(clock.nextAsync)
-                    .then(clock.nextAsync)
-                    .then(clock.nextAsync)
-                    .then(function () {
-                        assert.equals(callback.callCount, 3);
-                    });
-            });
-
-            it("subsequent calls do not fire intervals canceled in promises", function () {
-                var id;
-                var clock = this.clock;
-                var callback = sinon.spy(function () {
-                    if (callback.callCount === 3) {
-                        global.Promise.resolve().then(function () {
-                            clearInterval(id);
-                        });
-                    }
-                });
-
-                id = this.clock.setInterval(callback, 10);
-                return this.clock
-                    .nextAsync()
-                    .then(clock.nextAsync)
-                    .then(clock.nextAsync)
-                    .then(clock.nextAsync)
-                    .then(function () {
-                        assert.equals(callback.callCount, 3);
-                    });
-            });
-
-            it("advances the clock based on when the timer was supposed to be called", function () {
-                var clock = this.clock;
-                clock.setTimeout(sinon.spy(), 55);
-                return clock.nextAsync().then(function () {
-                    assert.equals(clock.now, 55);
-                });
-            });
-
-            it("returns the current now value", function () {
-                var clock = this.clock;
-                clock.setTimeout(sinon.spy(), 55);
-                return clock.nextAsync().then(function (value) {
-                    assert.equals(clock.now, value);
-                });
-            });
-
-            it("should settle user-created promises", function () {
-                var spy = sinon.spy();
-
-                setTimeout(function () {
-                    global.Promise.resolve().then(spy);
-                }, 55);
-
-                return this.clock.nextAsync().then(function () {
-                    assert(spy.calledOnce);
-                });
-            });
-
-            it("should settle nested user-created promises", function () {
-                var spy = sinon.spy();
-
-                setTimeout(function () {
-                    global.Promise.resolve().then(function () {
-                        global.Promise.resolve().then(function () {
-                            global.Promise.resolve().then(spy);
-                        });
-                    });
-                }, 55);
-
-                return this.clock.nextAsync().then(function () {
-                    assert(spy.calledOnce);
-                });
-            });
-
-            it("should settle local promises before firing timers", function () {
-                var spies = [sinon.spy(), sinon.spy()];
-
-                global.Promise.resolve().then(spies[0]);
-
-                setTimeout(spies[1], 55);
-
-                return this.clock.nextAsync().then(function () {
-                    assert(spies[0].calledBefore(spies[1]));
-                });
+            return this.clock.nextAsync().then(function () {
+                assert(stub.called);
             });
         });
-    }
+
+        it("does not trigger simultaneous timers", function () {
+            var spies = [sinon.spy(), sinon.spy()];
+            this.clock.setTimeout(spies[0], 100);
+            this.clock.setTimeout(spies[1], 100);
+
+            return this.clock.nextAsync().then(function () {
+                assert(spies[0].called);
+                assert.isFalse(spies[1].called);
+            });
+        });
+
+        it("subsequent calls trigger simultaneous timers", function () {
+            var spies = [sinon.spy(), sinon.spy(), sinon.spy(), sinon.spy()];
+            var clock = this.clock;
+            this.clock.setTimeout(spies[0], 100);
+            this.clock.setTimeout(spies[1], 100);
+            this.clock.setTimeout(spies[2], 99);
+            this.clock.setTimeout(spies[3], 100);
+
+            return this.clock
+                .nextAsync()
+                .then(function () {
+                    assert(spies[2].called);
+                    assert.isFalse(spies[0].called);
+                    assert.isFalse(spies[1].called);
+                    assert.isFalse(spies[3].called);
+                    return clock.nextAsync();
+                })
+                .then(function () {
+                    assert(spies[0].called);
+                    assert.isFalse(spies[1].called);
+                    assert.isFalse(spies[3].called);
+
+                    return clock.nextAsync();
+                })
+                .then(function () {
+                    assert(spies[1].called);
+                    assert.isFalse(spies[3].called);
+
+                    return clock.nextAsync();
+                })
+                .then(function () {
+                    assert(spies[3].called);
+                });
+        });
+
+        it("subsequent calls triggers simultaneous timers with zero callAt", function () {
+            var test = this;
+            var spies = [
+                sinon.spy(function () {
+                    test.clock.setTimeout(spies[1], 0);
+                }),
+                sinon.spy(),
+                sinon.spy(),
+            ];
+
+            // First spy calls another setTimeout with delay=0
+            this.clock.setTimeout(spies[0], 0);
+            this.clock.setTimeout(spies[2], 10);
+
+            return this.clock
+                .nextAsync()
+                .then(function () {
+                    assert(spies[0].called);
+                    assert.isFalse(spies[1].called);
+
+                    return test.clock.nextAsync();
+                })
+                .then(function () {
+                    assert(spies[1].called);
+
+                    return test.clock.nextAsync();
+                })
+                .then(function () {
+                    assert(spies[2].called);
+                });
+        });
+
+        it("subsequent calls in promises triggers simultaneous timers with zero callAt", function () {
+            var test = this;
+            var spies = [
+                sinon.spy(function () {
+                    global.Promise.resolve().then(function () {
+                        test.clock.setTimeout(spies[1], 0);
+                    });
+                }),
+                sinon.spy(),
+                sinon.spy(),
+            ];
+
+            // First spy calls another setTimeout with delay=0
+            this.clock.setTimeout(spies[0], 0);
+            this.clock.setTimeout(spies[2], 10);
+
+            return this.clock
+                .nextAsync()
+                .then(function () {
+                    assert(spies[0].called);
+                    assert.isFalse(spies[1].called);
+
+                    return test.clock.nextAsync();
+                })
+                .then(function () {
+                    assert(spies[1].called);
+
+                    return test.clock.nextAsync();
+                })
+                .then(function () {
+                    assert(spies[2].called);
+                });
+        });
+
+        it("throws exception thrown by timer", function () {
+            var clock = this.clock;
+            var stub = sinon.stub().throws();
+            var catchSpy = sinon.spy();
+
+            clock.setTimeout(stub, 100);
+
+            return clock
+                .nextAsync()
+                .catch(catchSpy)
+                .then(function () {
+                    assert(catchSpy.calledOnce);
+
+                    assert(stub.called);
+                });
+        });
+
+        it("calls function with global object or null (strict mode) as this", function () {
+            var clock = this.clock;
+            var stub = sinon.stub().throws();
+            var catchSpy = sinon.spy();
+            clock.setTimeout(stub, 100);
+
+            return clock
+                .nextAsync()
+                .catch(catchSpy)
+                .then(function () {
+                    assert(catchSpy.calledOnce);
+
+                    assert(stub.calledOn(global) || stub.calledOn(null));
+                });
+        });
+
+        it("subsequent calls trigger in the order scheduled", function () {
+            var clock = this.clock;
+            var spies = [sinon.spy(), sinon.spy()];
+            this.clock.setTimeout(spies[0], 13);
+            this.clock.setTimeout(spies[1], 11);
+
+            return this.clock
+                .nextAsync()
+                .then(function () {
+                    return clock.nextAsync();
+                })
+                .then(function () {
+                    assert(spies[1].calledBefore(spies[0]));
+                });
+        });
+
+        it("subsequent calls create updated Date", function () {
+            var clock = this.clock;
+            var spy = sinon.spy();
+
+            this.clock.setInterval(function () {
+                spy(new Date().getTime());
+            }, 10);
+
+            return this.clock
+                .nextAsync()
+                .then(clock.nextAsync)
+                .then(clock.nextAsync)
+                .then(clock.nextAsync)
+                .then(clock.nextAsync)
+                .then(clock.nextAsync)
+                .then(clock.nextAsync)
+                .then(clock.nextAsync)
+                .then(clock.nextAsync)
+                .then(clock.nextAsync)
+                .then(function () {
+                    assert.equals(spy.callCount, 10);
+                    assert(spy.calledWith(10));
+                    assert(spy.calledWith(20));
+                    assert(spy.calledWith(30));
+                    assert(spy.calledWith(40));
+                    assert(spy.calledWith(50));
+                    assert(spy.calledWith(60));
+                    assert(spy.calledWith(70));
+                    assert(spy.calledWith(80));
+                    assert(spy.calledWith(90));
+                    assert(spy.calledWith(100));
+                });
+        });
+
+        it("subsequent calls in promises create updated Date", function () {
+            var clock = this.clock;
+            var spy = sinon.spy();
+
+            this.clock.setInterval(function () {
+                global.Promise.resolve().then(function () {
+                    spy(new Date().getTime());
+                });
+            }, 10);
+
+            return this.clock
+                .nextAsync()
+                .then(clock.nextAsync)
+                .then(clock.nextAsync)
+                .then(clock.nextAsync)
+                .then(clock.nextAsync)
+                .then(clock.nextAsync)
+                .then(clock.nextAsync)
+                .then(clock.nextAsync)
+                .then(clock.nextAsync)
+                .then(clock.nextAsync)
+                .then(function () {
+                    assert.equals(spy.callCount, 10);
+                    assert(spy.calledWith(10));
+                    assert(spy.calledWith(20));
+                    assert(spy.calledWith(30));
+                    assert(spy.calledWith(40));
+                    assert(spy.calledWith(50));
+                    assert(spy.calledWith(60));
+                    assert(spy.calledWith(70));
+                    assert(spy.calledWith(80));
+                    assert(spy.calledWith(90));
+                    assert(spy.calledWith(100));
+                });
+        });
+
+        it("subsequent calls trigger timeouts and intervals in the order scheduled", function () {
+            var clock = this.clock;
+            var spies = [sinon.spy(), sinon.spy()];
+            this.clock.setInterval(spies[0], 10);
+            this.clock.setTimeout(spies[1], 50);
+
+            return this.clock
+                .nextAsync()
+                .then(clock.nextAsync)
+                .then(clock.nextAsync)
+                .then(clock.nextAsync)
+                .then(clock.nextAsync)
+                .then(clock.nextAsync)
+                .then(function () {
+                    assert(spies[0].calledBefore(spies[1]));
+                    assert.equals(spies[0].callCount, 5);
+                    assert.equals(spies[1].callCount, 1);
+                });
+        });
+
+        it("subsequent calls do not fire canceled intervals", function () {
+            var id;
+            var clock = this.clock;
+            var callback = sinon.spy(function () {
+                if (callback.callCount === 3) {
+                    clearInterval(id);
+                }
+            });
+
+            id = this.clock.setInterval(callback, 10);
+            return this.clock
+                .nextAsync()
+                .then(clock.nextAsync)
+                .then(clock.nextAsync)
+                .then(clock.nextAsync)
+                .then(function () {
+                    assert.equals(callback.callCount, 3);
+                });
+        });
+
+        it("subsequent calls do not fire intervals canceled in promises", function () {
+            var id;
+            var clock = this.clock;
+            var callback = sinon.spy(function () {
+                if (callback.callCount === 3) {
+                    global.Promise.resolve().then(function () {
+                        clearInterval(id);
+                    });
+                }
+            });
+
+            id = this.clock.setInterval(callback, 10);
+            return this.clock
+                .nextAsync()
+                .then(clock.nextAsync)
+                .then(clock.nextAsync)
+                .then(clock.nextAsync)
+                .then(function () {
+                    assert.equals(callback.callCount, 3);
+                });
+        });
+
+        it("advances the clock based on when the timer was supposed to be called", function () {
+            var clock = this.clock;
+            clock.setTimeout(sinon.spy(), 55);
+            return clock.nextAsync().then(function () {
+                assert.equals(clock.now, 55);
+            });
+        });
+
+        it("returns the current now value", function () {
+            var clock = this.clock;
+            clock.setTimeout(sinon.spy(), 55);
+            return clock.nextAsync().then(function (value) {
+                assert.equals(clock.now, value);
+            });
+        });
+
+        it("should settle user-created promises", function () {
+            var spy = sinon.spy();
+
+            setTimeout(function () {
+                global.Promise.resolve().then(spy);
+            }, 55);
+
+            return this.clock.nextAsync().then(function () {
+                assert(spy.calledOnce);
+            });
+        });
+
+        it("should settle nested user-created promises", function () {
+            var spy = sinon.spy();
+
+            setTimeout(function () {
+                global.Promise.resolve().then(function () {
+                    global.Promise.resolve().then(function () {
+                        global.Promise.resolve().then(spy);
+                    });
+                });
+            }, 55);
+
+            return this.clock.nextAsync().then(function () {
+                assert(spy.calledOnce);
+            });
+        });
+
+        it("should settle local promises before firing timers", function () {
+            var spies = [sinon.spy(), sinon.spy()];
+
+            global.Promise.resolve().then(spies[0]);
+
+            setTimeout(spies[1], 55);
+
+            return this.clock.nextAsync().then(function () {
+                assert(spies[0].calledBefore(spies[1]));
+            });
+        });
+    });
 
     describe("runAll", function () {
         it("if there are no timers just return", function () {
@@ -2485,198 +2481,202 @@ describe("FakeTimers", function () {
         });
     });
 
-    if (typeof global.Promise !== "undefined") {
-        describe("runAllAsync", function () {
-            it("if there are no timers just return", function () {
-                this.clock = FakeTimers.createClock();
-                return this.clock.runAllAsync();
-            });
+    describe("runAllAsync", function () {
+        before(function () {
+            if (!promisePresent) {
+                this.skip();
+            }
+        });
 
-            it("runs all timers", function () {
-                this.clock = FakeTimers.createClock();
-                var spies = [sinon.spy(), sinon.spy()];
-                this.clock.setTimeout(spies[0], 10);
-                this.clock.setTimeout(spies[1], 50);
+        it("if there are no timers just return", function () {
+            this.clock = FakeTimers.createClock();
+            return this.clock.runAllAsync();
+        });
 
-                return this.clock.runAllAsync().then(function () {
-                    assert(spies[0].called);
-                    assert(spies[1].called);
-                });
-            });
+        it("runs all timers", function () {
+            this.clock = FakeTimers.createClock();
+            var spies = [sinon.spy(), sinon.spy()];
+            this.clock.setTimeout(spies[0], 10);
+            this.clock.setTimeout(spies[1], 50);
 
-            it("new timers added while running are also run", function () {
-                this.clock = FakeTimers.createClock();
-                var test = this;
-                var spies = [
-                    sinon.spy(function () {
-                        test.clock.setTimeout(spies[1], 50);
-                    }),
-                    sinon.spy(),
-                ];
-
-                // Spy calls another setTimeout
-                this.clock.setTimeout(spies[0], 10);
-
-                return this.clock.runAllAsync().then(function () {
-                    assert(spies[0].called);
-                    assert(spies[1].called);
-                });
-            });
-
-            it("new timers added in promises while running are also run", function () {
-                this.clock = FakeTimers.createClock();
-                var test = this;
-                var spies = [
-                    sinon.spy(function () {
-                        global.Promise.resolve().then(function () {
-                            test.clock.setTimeout(spies[1], 50);
-                        });
-                    }),
-                    sinon.spy(),
-                ];
-
-                // Spy calls another setTimeout
-                this.clock.setTimeout(spies[0], 10);
-
-                return this.clock.runAllAsync().then(function () {
-                    assert(spies[0].called);
-                    assert(spies[1].called);
-                });
-            });
-
-            it("throws before allowing infinite recursion", function () {
-                this.clock = FakeTimers.createClock(0, 100);
-                var test = this;
-                var recursiveCallback = function () {
-                    test.clock.setTimeout(recursiveCallback, 10);
-                };
-                var catchSpy = sinon.spy();
-
-                this.clock.setTimeout(recursiveCallback, 10);
-
-                return test.clock
-                    .runAllAsync()
-                    .catch(catchSpy)
-                    .then(function () {
-                        assert(catchSpy.calledOnce);
-                    });
-            });
-
-            it("throws before allowing infinite recursion from promises", function () {
-                this.clock = FakeTimers.createClock(0, 100);
-                var test = this;
-                var recursiveCallback = function () {
-                    global.Promise.resolve().then(function () {
-                        test.clock.setTimeout(recursiveCallback, 10);
-                    });
-                };
-                var catchSpy = sinon.spy();
-
-                this.clock.setTimeout(recursiveCallback, 10);
-
-                return test.clock
-                    .runAllAsync()
-                    .catch(catchSpy)
-                    .then(function () {
-                        assert(catchSpy.calledOnce);
-                    });
-            });
-
-            it("the loop limit can be set when creating a clock", function () {
-                this.clock = FakeTimers.createClock(0, 1);
-                var test = this;
-                var catchSpy = sinon.spy();
-
-                var spies = [sinon.spy(), sinon.spy()];
-                this.clock.setTimeout(spies[0], 10);
-                this.clock.setTimeout(spies[1], 50);
-
-                return test.clock
-                    .runAllAsync()
-                    .catch(catchSpy)
-                    .then(function () {
-                        assert(catchSpy.calledOnce);
-                    });
-            });
-
-            it("the loop limit can be set when installing a clock", function () {
-                this.clock = FakeTimers.install({ loopLimit: 1 });
-                var test = this;
-                var catchSpy = sinon.spy();
-
-                var spies = [sinon.spy(), sinon.spy()];
-                setTimeout(spies[0], 10);
-                setTimeout(spies[1], 50);
-
-                return test.clock
-                    .runAllAsync()
-                    .catch(catchSpy)
-                    .then(function () {
-                        assert(catchSpy.calledOnce);
-
-                        test.clock.uninstall();
-                    });
-            });
-
-            it("should settle user-created promises", function () {
-                this.clock = FakeTimers.createClock();
-                var spy = sinon.spy();
-
-                this.clock.setTimeout(function () {
-                    global.Promise.resolve().then(spy);
-                }, 55);
-
-                return this.clock.runAllAsync().then(function () {
-                    assert(spy.calledOnce);
-                });
-            });
-
-            it("should settle nested user-created promises", function () {
-                this.clock = FakeTimers.createClock();
-                var spy = sinon.spy();
-
-                this.clock.setTimeout(function () {
-                    global.Promise.resolve().then(function () {
-                        global.Promise.resolve().then(function () {
-                            global.Promise.resolve().then(spy);
-                        });
-                    });
-                }, 55);
-
-                return this.clock.runAllAsync().then(function () {
-                    assert(spy.calledOnce);
-                });
-            });
-
-            it("should settle local promises before firing timers", function () {
-                this.clock = FakeTimers.createClock();
-                var spies = [sinon.spy(), sinon.spy()];
-
-                global.Promise.resolve().then(spies[0]);
-
-                this.clock.setTimeout(spies[1], 55);
-
-                return this.clock.runAllAsync().then(function () {
-                    assert(spies[0].calledBefore(spies[1]));
-                });
-            });
-
-            it("should settle user-created promises before firing more timers", function () {
-                this.clock = FakeTimers.createClock();
-                var spies = [sinon.spy(), sinon.spy()];
-
-                this.clock.setTimeout(function () {
-                    global.Promise.resolve().then(spies[0]);
-                }, 55);
-
-                this.clock.setTimeout(spies[1], 75);
-
-                return this.clock.runAllAsync().then(function () {
-                    assert(spies[0].calledBefore(spies[1]));
-                });
+            return this.clock.runAllAsync().then(function () {
+                assert(spies[0].called);
+                assert(spies[1].called);
             });
         });
-    }
+
+        it("new timers added while running are also run", function () {
+            this.clock = FakeTimers.createClock();
+            var test = this;
+            var spies = [
+                sinon.spy(function () {
+                    test.clock.setTimeout(spies[1], 50);
+                }),
+                sinon.spy(),
+            ];
+
+            // Spy calls another setTimeout
+            this.clock.setTimeout(spies[0], 10);
+
+            return this.clock.runAllAsync().then(function () {
+                assert(spies[0].called);
+                assert(spies[1].called);
+            });
+        });
+
+        it("new timers added in promises while running are also run", function () {
+            this.clock = FakeTimers.createClock();
+            var test = this;
+            var spies = [
+                sinon.spy(function () {
+                    global.Promise.resolve().then(function () {
+                        test.clock.setTimeout(spies[1], 50);
+                    });
+                }),
+                sinon.spy(),
+            ];
+
+            // Spy calls another setTimeout
+            this.clock.setTimeout(spies[0], 10);
+
+            return this.clock.runAllAsync().then(function () {
+                assert(spies[0].called);
+                assert(spies[1].called);
+            });
+        });
+
+        it("throws before allowing infinite recursion", function () {
+            this.clock = FakeTimers.createClock(0, 100);
+            var test = this;
+            var recursiveCallback = function () {
+                test.clock.setTimeout(recursiveCallback, 10);
+            };
+            var catchSpy = sinon.spy();
+
+            this.clock.setTimeout(recursiveCallback, 10);
+
+            return test.clock
+                .runAllAsync()
+                .catch(catchSpy)
+                .then(function () {
+                    assert(catchSpy.calledOnce);
+                });
+        });
+
+        it("throws before allowing infinite recursion from promises", function () {
+            this.clock = FakeTimers.createClock(0, 100);
+            var test = this;
+            var recursiveCallback = function () {
+                global.Promise.resolve().then(function () {
+                    test.clock.setTimeout(recursiveCallback, 10);
+                });
+            };
+            var catchSpy = sinon.spy();
+
+            this.clock.setTimeout(recursiveCallback, 10);
+
+            return test.clock
+                .runAllAsync()
+                .catch(catchSpy)
+                .then(function () {
+                    assert(catchSpy.calledOnce);
+                });
+        });
+
+        it("the loop limit can be set when creating a clock", function () {
+            this.clock = FakeTimers.createClock(0, 1);
+            var test = this;
+            var catchSpy = sinon.spy();
+
+            var spies = [sinon.spy(), sinon.spy()];
+            this.clock.setTimeout(spies[0], 10);
+            this.clock.setTimeout(spies[1], 50);
+
+            return test.clock
+                .runAllAsync()
+                .catch(catchSpy)
+                .then(function () {
+                    assert(catchSpy.calledOnce);
+                });
+        });
+
+        it("the loop limit can be set when installing a clock", function () {
+            this.clock = FakeTimers.install({ loopLimit: 1 });
+            var test = this;
+            var catchSpy = sinon.spy();
+
+            var spies = [sinon.spy(), sinon.spy()];
+            setTimeout(spies[0], 10);
+            setTimeout(spies[1], 50);
+
+            return test.clock
+                .runAllAsync()
+                .catch(catchSpy)
+                .then(function () {
+                    assert(catchSpy.calledOnce);
+
+                    test.clock.uninstall();
+                });
+        });
+
+        it("should settle user-created promises", function () {
+            this.clock = FakeTimers.createClock();
+            var spy = sinon.spy();
+
+            this.clock.setTimeout(function () {
+                global.Promise.resolve().then(spy);
+            }, 55);
+
+            return this.clock.runAllAsync().then(function () {
+                assert(spy.calledOnce);
+            });
+        });
+
+        it("should settle nested user-created promises", function () {
+            this.clock = FakeTimers.createClock();
+            var spy = sinon.spy();
+
+            this.clock.setTimeout(function () {
+                global.Promise.resolve().then(function () {
+                    global.Promise.resolve().then(function () {
+                        global.Promise.resolve().then(spy);
+                    });
+                });
+            }, 55);
+
+            return this.clock.runAllAsync().then(function () {
+                assert(spy.calledOnce);
+            });
+        });
+
+        it("should settle local promises before firing timers", function () {
+            this.clock = FakeTimers.createClock();
+            var spies = [sinon.spy(), sinon.spy()];
+
+            global.Promise.resolve().then(spies[0]);
+
+            this.clock.setTimeout(spies[1], 55);
+
+            return this.clock.runAllAsync().then(function () {
+                assert(spies[0].calledBefore(spies[1]));
+            });
+        });
+
+        it("should settle user-created promises before firing more timers", function () {
+            this.clock = FakeTimers.createClock();
+            var spies = [sinon.spy(), sinon.spy()];
+
+            this.clock.setTimeout(function () {
+                global.Promise.resolve().then(spies[0]);
+            }, 55);
+
+            this.clock.setTimeout(spies[1], 75);
+
+            return this.clock.runAllAsync().then(function () {
+                assert(spies[0].calledBefore(spies[1]));
+            });
+        });
+    });
 
     describe("runToLast", function () {
         it("returns current time when there are no timers", function () {
@@ -2795,57 +2795,85 @@ describe("FakeTimers", function () {
         });
     });
 
-    if (typeof global.Promise !== "undefined") {
-        describe("runToLastAsync", function () {
-            it("returns current time when there are no timers", function () {
-                this.clock = FakeTimers.createClock();
+    describe("runToLastAsync", function () {
+        before(function () {
+            if (!promisePresent) {
+                this.skip();
+            }
+        });
+        it("returns current time when there are no timers", function () {
+            this.clock = FakeTimers.createClock();
 
-                return this.clock.runToLastAsync().then(function (time) {
-                    assert.equals(time, 0);
-                });
+            return this.clock.runToLastAsync().then(function (time) {
+                assert.equals(time, 0);
             });
+        });
 
-            it("runs all existing timers", function () {
-                this.clock = FakeTimers.createClock();
-                var spies = [sinon.spy(), sinon.spy()];
-                this.clock.setTimeout(spies[0], 10);
-                this.clock.setTimeout(spies[1], 50);
+        it("runs all existing timers", function () {
+            this.clock = FakeTimers.createClock();
+            var spies = [sinon.spy(), sinon.spy()];
+            this.clock.setTimeout(spies[0], 10);
+            this.clock.setTimeout(spies[1], 50);
 
-                return this.clock.runToLastAsync().then(function () {
-                    assert(spies[0].called);
-                    assert(spies[1].called);
-                });
+            return this.clock.runToLastAsync().then(function () {
+                assert(spies[0].called);
+                assert(spies[1].called);
             });
+        });
 
-            it("returns time of the last timer", function () {
-                this.clock = FakeTimers.createClock();
-                var spies = [sinon.spy(), sinon.spy()];
-                this.clock.setTimeout(spies[0], 10);
-                this.clock.setTimeout(spies[1], 50);
+        it("returns time of the last timer", function () {
+            this.clock = FakeTimers.createClock();
+            var spies = [sinon.spy(), sinon.spy()];
+            this.clock.setTimeout(spies[0], 10);
+            this.clock.setTimeout(spies[1], 50);
 
-                return this.clock.runToLastAsync().then(function (time) {
-                    assert.equals(time, 50);
-                });
+            return this.clock.runToLastAsync().then(function (time) {
+                assert.equals(time, 50);
             });
+        });
 
-            it("runs all existing timers when two timers are matched for being last", function () {
-                this.clock = FakeTimers.createClock();
-                var spies = [sinon.spy(), sinon.spy()];
-                this.clock.setTimeout(spies[0], 10);
-                this.clock.setTimeout(spies[1], 10);
+        it("runs all existing timers when two timers are matched for being last", function () {
+            this.clock = FakeTimers.createClock();
+            var spies = [sinon.spy(), sinon.spy()];
+            this.clock.setTimeout(spies[0], 10);
+            this.clock.setTimeout(spies[1], 10);
 
-                return this.clock.runToLastAsync().then(function () {
-                    assert(spies[0].called);
-                    assert(spies[1].called);
-                });
+            return this.clock.runToLastAsync().then(function () {
+                assert(spies[0].called);
+                assert(spies[1].called);
             });
+        });
 
-            it("new timers added with a call time later than the last existing timer are NOT run", function () {
+        it("new timers added with a call time later than the last existing timer are NOT run", function () {
+            this.clock = FakeTimers.createClock();
+            var test = this;
+            var spies = [
+                sinon.spy(function () {
+                    test.clock.setTimeout(spies[1], 50);
+                }),
+                sinon.spy(),
+            ];
+
+            // Spy calls another setTimeout
+            this.clock.setTimeout(spies[0], 10);
+
+            return this.clock.runToLastAsync().then(function () {
+                assert.isTrue(spies[0].called);
+                assert.isFalse(spies[1].called);
+            });
+        });
+
+        it(
+            "new timers added from a promise with a call time later than the last existing timer" +
+                "are NOT run",
+            function () {
                 this.clock = FakeTimers.createClock();
                 var test = this;
                 var spies = [
                     sinon.spy(function () {
-                        test.clock.setTimeout(spies[1], 50);
+                        global.Promise.resolve().then(function () {
+                            test.clock.setTimeout(spies[1], 50);
+                        });
                     }),
                     sinon.spy(),
                 ];
@@ -2857,40 +2885,43 @@ describe("FakeTimers", function () {
                     assert.isTrue(spies[0].called);
                     assert.isFalse(spies[1].called);
                 });
+            }
+        );
+
+        it("new timers added with a call time ealier than the last existing timer are run", function () {
+            this.clock = FakeTimers.createClock();
+            var test = this;
+            var spies = [
+                sinon.spy(),
+                sinon.spy(function () {
+                    test.clock.setTimeout(spies[2], 50);
+                }),
+                sinon.spy(),
+            ];
+
+            this.clock.setTimeout(spies[0], 100);
+            // Spy calls another setTimeout
+            this.clock.setTimeout(spies[1], 10);
+
+            return this.clock.runToLastAsync().then(function () {
+                assert.isTrue(spies[0].called);
+                assert.isTrue(spies[1].called);
+                assert.isTrue(spies[2].called);
             });
+        });
 
-            it(
-                "new timers added from a promise with a call time later than the last existing timer" +
-                    "are NOT run",
-                function () {
-                    this.clock = FakeTimers.createClock();
-                    var test = this;
-                    var spies = [
-                        sinon.spy(function () {
-                            global.Promise.resolve().then(function () {
-                                test.clock.setTimeout(spies[1], 50);
-                            });
-                        }),
-                        sinon.spy(),
-                    ];
-
-                    // Spy calls another setTimeout
-                    this.clock.setTimeout(spies[0], 10);
-
-                    return this.clock.runToLastAsync().then(function () {
-                        assert.isTrue(spies[0].called);
-                        assert.isFalse(spies[1].called);
-                    });
-                }
-            );
-
-            it("new timers added with a call time ealier than the last existing timer are run", function () {
+        it(
+            "new timers added from a promise with a call time ealier than the last existing timer" +
+                "are run",
+            function () {
                 this.clock = FakeTimers.createClock();
                 var test = this;
                 var spies = [
                     sinon.spy(),
                     sinon.spy(function () {
-                        test.clock.setTimeout(spies[2], 50);
+                        global.Promise.resolve().then(function () {
+                            test.clock.setTimeout(spies[2], 50);
+                        });
                     }),
                     sinon.spy(),
                 ];
@@ -2904,129 +2935,101 @@ describe("FakeTimers", function () {
                     assert.isTrue(spies[1].called);
                     assert.isTrue(spies[2].called);
                 });
-            });
+            }
+        );
 
-            it(
-                "new timers added from a promise with a call time ealier than the last existing timer" +
-                    "are run",
-                function () {
-                    this.clock = FakeTimers.createClock();
-                    var test = this;
-                    var spies = [
-                        sinon.spy(),
-                        sinon.spy(function () {
-                            global.Promise.resolve().then(function () {
-                                test.clock.setTimeout(spies[2], 50);
-                            });
-                        }),
-                        sinon.spy(),
-                    ];
+        it("new timers cannot cause an infinite loop", function () {
+            this.clock = FakeTimers.createClock();
+            var test = this;
+            var spy = sinon.spy();
+            var recursiveCallback = function () {
+                test.clock.setTimeout(recursiveCallback, 0);
+            };
 
-                    this.clock.setTimeout(spies[0], 100);
-                    // Spy calls another setTimeout
-                    this.clock.setTimeout(spies[1], 10);
+            this.clock.setTimeout(recursiveCallback, 0);
+            this.clock.setTimeout(spy, 100);
 
-                    return this.clock.runToLastAsync().then(function () {
-                        assert.isTrue(spies[0].called);
-                        assert.isTrue(spies[1].called);
-                        assert.isTrue(spies[2].called);
-                    });
-                }
-            );
-
-            it("new timers cannot cause an infinite loop", function () {
-                this.clock = FakeTimers.createClock();
-                var test = this;
-                var spy = sinon.spy();
-                var recursiveCallback = function () {
-                    test.clock.setTimeout(recursiveCallback, 0);
-                };
-
-                this.clock.setTimeout(recursiveCallback, 0);
-                this.clock.setTimeout(spy, 100);
-
-                return this.clock.runToLastAsync().then(function () {
-                    assert.isTrue(spy.called);
-                });
-            });
-
-            it("new timers created from promises cannot cause an infinite loop", function () {
-                this.clock = FakeTimers.createClock();
-                var test = this;
-                var spy = sinon.spy();
-                var recursiveCallback = function () {
-                    global.Promise.resolve().then(function () {
-                        test.clock.setTimeout(recursiveCallback, 0);
-                    });
-                };
-
-                this.clock.setTimeout(recursiveCallback, 0);
-                this.clock.setTimeout(spy, 100);
-
-                return this.clock.runToLastAsync().then(function () {
-                    assert.isTrue(spy.called);
-                });
-            });
-
-            it("should settle user-created promises", function () {
-                this.clock = FakeTimers.createClock();
-                var spy = sinon.spy();
-
-                this.clock.setTimeout(function () {
-                    global.Promise.resolve().then(spy);
-                }, 55);
-
-                return this.clock.runToLastAsync().then(function () {
-                    assert(spy.calledOnce);
-                });
-            });
-
-            it("should settle nested user-created promises", function () {
-                this.clock = FakeTimers.createClock();
-                var spy = sinon.spy();
-
-                this.clock.setTimeout(function () {
-                    global.Promise.resolve().then(function () {
-                        global.Promise.resolve().then(function () {
-                            global.Promise.resolve().then(spy);
-                        });
-                    });
-                }, 55);
-
-                return this.clock.runToLastAsync().then(function () {
-                    assert(spy.calledOnce);
-                });
-            });
-
-            it("should settle local promises before firing timers", function () {
-                this.clock = FakeTimers.createClock();
-                var spies = [sinon.spy(), sinon.spy()];
-
-                global.Promise.resolve().then(spies[0]);
-
-                this.clock.setTimeout(spies[1], 55);
-
-                return this.clock.runToLastAsync().then(function () {
-                    assert(spies[0].calledBefore(spies[1]));
-                });
-            });
-
-            it("should settle user-created promises before firing more timers", function () {
-                this.clock = FakeTimers.createClock();
-                var spies = [sinon.spy(), sinon.spy()];
-
-                this.clock.setTimeout(function () {
-                    global.Promise.resolve().then(spies[0]);
-                }, 55);
-
-                this.clock.setTimeout(spies[1], 75);
-
-                return this.clock.runToLastAsync().then(function () {
-                    assert(spies[0].calledBefore(spies[1]));
-                });
+            return this.clock.runToLastAsync().then(function () {
+                assert.isTrue(spy.called);
             });
         });
-    }
+
+        it("new timers created from promises cannot cause an infinite loop", function () {
+            this.clock = FakeTimers.createClock();
+            var test = this;
+            var spy = sinon.spy();
+            var recursiveCallback = function () {
+                global.Promise.resolve().then(function () {
+                    test.clock.setTimeout(recursiveCallback, 0);
+                });
+            };
+
+            this.clock.setTimeout(recursiveCallback, 0);
+            this.clock.setTimeout(spy, 100);
+
+            return this.clock.runToLastAsync().then(function () {
+                assert.isTrue(spy.called);
+            });
+        });
+
+        it("should settle user-created promises", function () {
+            this.clock = FakeTimers.createClock();
+            var spy = sinon.spy();
+
+            this.clock.setTimeout(function () {
+                global.Promise.resolve().then(spy);
+            }, 55);
+
+            return this.clock.runToLastAsync().then(function () {
+                assert(spy.calledOnce);
+            });
+        });
+
+        it("should settle nested user-created promises", function () {
+            this.clock = FakeTimers.createClock();
+            var spy = sinon.spy();
+
+            this.clock.setTimeout(function () {
+                global.Promise.resolve().then(function () {
+                    global.Promise.resolve().then(function () {
+                        global.Promise.resolve().then(spy);
+                    });
+                });
+            }, 55);
+
+            return this.clock.runToLastAsync().then(function () {
+                assert(spy.calledOnce);
+            });
+        });
+
+        it("should settle local promises before firing timers", function () {
+            this.clock = FakeTimers.createClock();
+            var spies = [sinon.spy(), sinon.spy()];
+
+            global.Promise.resolve().then(spies[0]);
+
+            this.clock.setTimeout(spies[1], 55);
+
+            return this.clock.runToLastAsync().then(function () {
+                assert(spies[0].calledBefore(spies[1]));
+            });
+        });
+
+        it("should settle user-created promises before firing more timers", function () {
+            this.clock = FakeTimers.createClock();
+            var spies = [sinon.spy(), sinon.spy()];
+
+            this.clock.setTimeout(function () {
+                global.Promise.resolve().then(spies[0]);
+            }, 55);
+
+            this.clock.setTimeout(spies[1], 75);
+
+            return this.clock.runToLastAsync().then(function () {
+                assert(spies[0].calledBefore(spies[1]));
+            });
+        });
+    });
 
     describe("clearTimeout", function () {
         beforeEach(function () {
@@ -3424,23 +3427,25 @@ describe("FakeTimers", function () {
             assert.same(typeof this.clock.Date.now, typeof Date.now);
         });
 
-        if (Date.now) {
-            describe("now", function () {
-                it("returns clock.now", function () {
-                    /* eslint camelcase: "off" */
-                    var clock_now = this.clock.Date.now();
-                    var global_now = GlobalDate.now();
+        describe("now", function () {
+            it("returns clock.now", function () {
+                if (!Date.now) {
+                    this.skip();
+                }
+                /* eslint camelcase: "off" */
+                var clock_now = this.clock.Date.now();
+                var global_now = GlobalDate.now();
 
-                    assert(this.now <= clock_now && clock_now <= global_now);
-                });
+                assert(this.now <= clock_now && clock_now <= global_now);
             });
-        } else {
-            describe("unsupported now", function () {
-                it("is undefined", function () {
-                    assert.isUndefined(this.clock.Date.now);
-                });
+
+            it("is undefined", function () {
+                if (Date.now) {
+                    this.skip();
+                }
+                assert.isUndefined(this.clock.Date.now);
             });
-        }
+        });
 
         it("mirrors parse method", function () {
             assert.same(this.clock.Date.parse, Date.parse);
@@ -3457,19 +3462,21 @@ describe("FakeTimers", function () {
             );
         });
 
-        if (Date.toSource) {
-            describe("toSource", function () {
-                it("is mirrored", function () {
-                    assert.same(this.clock.Date.toSource(), Date.toSource());
-                });
+        describe("toSource", function () {
+            it("is mirrored", function () {
+                if (!Date.toSource) {
+                    this.skip();
+                }
+                assert.same(this.clock.Date.toSource(), Date.toSource());
             });
-        } else {
-            describe("unsupported toSource", function () {
-                it("is undefined", function () {
-                    assert.isUndefined(this.clock.Date.toSource);
-                });
+
+            it("is undefined", function () {
+                if (Date.toSource) {
+                    this.skip();
+                }
+                assert.isUndefined(this.clock.Date.toSource);
             });
-        }
+        });
 
         it("mirrors toString", function () {
             assert.same(this.clock.Date.toString(), Date.toString());
@@ -3754,6 +3761,7 @@ describe("FakeTimers", function () {
             });
         }
 
+        /* eslint-disable mocha/no-setup-in-describe */
         if (Object.getPrototypeOf(global)) {
             delete global.hasOwnPropertyTest;
             Object.getPrototypeOf(global).hasOwnPropertyTest = function () {};
@@ -3778,6 +3786,7 @@ describe("FakeTimers", function () {
 
             delete Object.getPrototypeOf(global).hasOwnPropertyTest;
         }
+        /* eslint-enable mocha/no-setup-in-describe */
 
         it("uninstalls global property on uninstall if it is present on the global object itself", function () {
             // Directly give the global object a tick method
@@ -4696,7 +4705,7 @@ describe("#187 - Support timeout.refresh in node environments", function () {
 
 describe("#347 - Support util.promisify once installed", function () {
     before(function () {
-        if (typeof global.Promise === "undefined" || !utilPromisify) {
+        if (!utilPromisifyAvailable) {
             this.skip();
         }
     });

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -4359,7 +4359,7 @@ describe("FakeTimers", function () {
             var i;
 
             for (i = 0; i < 99; i++) {
-                // eslint-disable-next-line no-loop-func,ie11/no-loop-func
+                // eslint-disable-next-line no-loop-func
                 clock.nextTick(function () {
                     i--;
                 });
@@ -4371,7 +4371,6 @@ describe("FakeTimers", function () {
         it("respects loopLimit from above in runMicrotasks", function () {
             var clock = FakeTimers.createClock(0, 100);
             for (var i = 0; i < 120; i++) {
-                // eslint-disable-next-line ie11/no-loop-func
                 clock.nextTick(function () {});
             }
             assert.exception(function () {
@@ -4512,7 +4511,6 @@ describe("FakeTimers", function () {
 
             for (i = 0; i < 5; i++) {
                 // yes, it's silly to create a function in a loop. This is a test, we can live with it
-                // eslint-disable-next-line ie11/no-loop-func
                 clock.setTimeout(function () {}, 100 * i);
             }
             var timers = clock.uninstall();


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Update fake-timers to use latest @sinonjs/eslint-config

#### Background (Problem in detail)  - optional
Was unable to write ES2015+ syntax, even though it should have worked. Also found lots of config I do not think is needed.

#### Solution
Removed all errors. Still 129 eslint warnings remaining - all concerning either missing jsdoc or errors in the types