### PR TITLE
Issue 390 implicit dependencies on faking interval

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -1614,22 +1614,23 @@ function withGlobal(_global) {
         }
 
         for (i = 0, l = clock.methods.length; i < l; i++) {
-            if (clock.methods[i] === "hrtime") {
+            const nameOfMethodToReplace = clock.methods[i];
+            if (nameOfMethodToReplace === "hrtime") {
                 if (
                     _global.process &&
                     typeof _global.process.hrtime === "function"
                 ) {
-                    hijackMethod(_global.process, clock.methods[i], clock);
+                    hijackMethod(_global.process, nameOfMethodToReplace, clock);
                 }
-            } else if (clock.methods[i] === "nextTick") {
+            } else if (nameOfMethodToReplace === "nextTick") {
                 if (
                     _global.process &&
                     typeof _global.process.nextTick === "function"
                 ) {
-                    hijackMethod(_global.process, clock.methods[i], clock);
+                    hijackMethod(_global.process, nameOfMethodToReplace, clock);
                 }
             } else {
-                hijackMethod(_global, clock.methods[i], clock);
+                hijackMethod(_global, nameOfMethodToReplace, clock);
             }
         }
 

--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -803,12 +803,6 @@ function withGlobal(_global) {
             } else {
                 if (_global[method] && _global[method].hadOwnProperty) {
                     _global[method] = clock[`_${method}`];
-                    if (
-                        method === "clearInterval" &&
-                        config.shouldAdvanceTime === true
-                    ) {
-                        _global[method](clock.attachedInterval);
-                    }
                 } else {
                     try {
                         delete _global[method];
@@ -817,6 +811,10 @@ function withGlobal(_global) {
                     }
                 }
             }
+        }
+
+        if (config.shouldAdvanceTime === true) {
+            _global.clearInterval(clock.attachedInterval);
         }
 
         // Prevent multiple executions which will completely remove these props
@@ -1602,6 +1600,19 @@ function withGlobal(_global) {
             });
         }
 
+        if (config.shouldAdvanceTime === true) {
+            const intervalTick = doIntervalTick.bind(
+                null,
+                clock,
+                config.advanceTimeDelta
+            );
+            const intervalId = _global.setInterval(
+                intervalTick,
+                config.advanceTimeDelta
+            );
+            clock.attachedInterval = intervalId;
+        }
+
         for (i = 0, l = clock.methods.length; i < l; i++) {
             if (clock.methods[i] === "hrtime") {
                 if (
@@ -1618,21 +1629,6 @@ function withGlobal(_global) {
                     hijackMethod(_global.process, clock.methods[i], clock);
                 }
             } else {
-                if (
-                    clock.methods[i] === "setInterval" &&
-                    config.shouldAdvanceTime === true
-                ) {
-                    const intervalTick = doIntervalTick.bind(
-                        null,
-                        clock,
-                        config.advanceTimeDelta
-                    );
-                    const intervalId = _global[clock.methods[i]](
-                        intervalTick,
-                        config.advanceTimeDelta
-                    );
-                    clock.attachedInterval = intervalId;
-                }
                 hijackMethod(_global, clock.methods[i], clock);
             }
         }

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -3955,6 +3955,24 @@ describe("FakeTimers", function () {
                 }
             }, interval);
         });
+
+        it("should not depend on having to stub setInterval or clearInterval to work", function (done) {
+            const origSetInterval = globalObject.setInterval;
+            const origClearInterval = globalObject.clearInterval;
+
+            var clock = FakeTimers.install({
+                shouldAdvanceTime: true,
+                toFake: ["setTimeout"],
+            });
+
+            assert.equals(globalObject.setInterval, origSetInterval);
+            assert.equals(globalObject.clearInterval, origClearInterval);
+
+            setTimeout(function () {
+                clock.uninstall();
+                done();
+            }, 0);
+        });
     });
 
     describe("requestAnimationFrame", function () {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Remove implicit dependency on `*Interval` functions in the shouldAdvanceTime feature.

#### Background (Problem in detail)  - optional
See #390
