### PR TITLE
fix: handle missing stack when throwing recursion errors

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -319,7 +319,7 @@ function withGlobal(_global) {
         );
 
         if (!job.error) {
-            return infiniteLoopError
+            return infiniteLoopError;
         }
 
         // pattern never matched in Node

--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -109,6 +109,7 @@ const globalObject = require("@sinonjs/commons").global;
  * @property {number} createdAt
  * @property {boolean} immediate
  * @property {number} id
+ * @property {Error} [error]
  */
 
 /**
@@ -208,8 +209,8 @@ function withGlobal(_global) {
     let isNearInfiniteLimit = false;
 
     /**
-     * @param clock
-     * @param i
+     * @param {Clock} clock
+     * @param {number} i
      */
     function checkIsNearInfiniteLimit(clock, i) {
         if (clock.loopLimit && i === clock.loopLimit - 1) {
@@ -309,13 +310,17 @@ function withGlobal(_global) {
     }
 
     /**
-     * @param clock
-     * @param job
+     * @param {Clock} clock
+     * @param {Timer} job
      */
     function getInfiniteLoopError(clock, job) {
         const infiniteLoopError = new Error(
             `Aborting after running ${clock.loopLimit} timers, assuming an infinite loop!`
         );
+
+        if (!job.error) {
+            return infiniteLoopError
+        }
 
         // pattern never matched in Node
         const computedTargetPattern = /target\.*[<|(|[].*?[>|\]|)]\s*/;


### PR DESCRIPTION
This is for #398 which I think we should land and release as 8.0.1. Guards against the error and falls back to the behavior of v7