### PR TITLE
chore: run prettier as part of eslint

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,8 +1,6 @@
 extends:
   - "@sinonjs/eslint-config"
-
-rules:
-  semi: error
+  - "plugin:prettier/recommended"
 
 overrides:
   - files: "**/*-test.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2326,6 +2326,12 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+      "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
+      "dev": true
+    },
     "eslint-plugin-compat": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-3.9.0.tgz",
@@ -2424,6 +2430,15 @@
       "requires": {
         "eslint-utils": "^2.1.0",
         "ramda": "^0.27.1"
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
+      "integrity": "sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-scope": {
@@ -2807,6 +2822,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -5959,6 +5980,15 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
       "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
       "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "process": {
       "version": "0.11.10",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
   "devDependencies": {
     "@sinonjs/eslint-config": "4.0.2",
     "@sinonjs/referee-sinon": "6.0.1",
+    "eslint-config-prettier": "8.3.0",
+    "eslint-plugin-prettier": "3.4.1",
     "husky": "4.2.1",
     "jsdom": "16.5.2",
     "lint-staged": "10.0.7",


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

I didn't know we had prettier set up (https://github.com/sinonjs/fake-timers/runs/3673842832?check_suite_focus=true) - it's better to just run it as part of `eslint` both for `eslint --fix` and the pre-commit hook. And my IDE will now autoformat on save 🙂 

Note that we can probably remove the `prettier --check` thing as `eslint` will now report any formatting errors.

Negates the need for #402

<!--
#### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->

<!--
#### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->
