### PR TITLE
CHANGELOG: give a hint about how to get type defs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 8.0.0 / 2021-09-15
 ==================
 
-  * Remove generated typescript definitions (#386)
+  * Remove generated typescript definitions. If you use this package with TypeScript, install `@types/sinonjs__fake-timers` after upgrading (#386)
   * Issue 390 implicit dependencies on faking interval (#391)
   * replace var with const/let (#392)
   * Retry - Add stack trace to code recursively scheduling timers #325  (#375)


### PR DESCRIPTION
The naming convention for DefinitelyTyped packages for namespaced packages is a bit obscure, so being explicit is nice (even if `tsc` does give the same hint).
