### PR TITLE
Drop node 12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,12 @@
 name: Node CI
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - '**'
+    push:
+        branches:
+            - main
+    pull_request:
+        branches:
+            - "**"
 
 jobs:
     prettier:
@@ -109,7 +109,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [12, 14, 16, 17]
+                node-version: [14, 16, 18]
 
         steps:
             - uses: actions/checkout@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@sinonjs/fake-timers",
-      "version": "9.1.0",
+      "version": "9.1.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"


### PR DESCRIPTION
This PR drops support for Node 12 and adds support for Node 18

See https://nodejs.org/en/about/releases/
