### PR TITLE
Fix #441: update spelling of prop descriptor prop

### DIFF
--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -3881,9 +3881,14 @@ describe("FakeTimers", function () {
                     return ["foo"];
                 }
 
-                Object.defineProperty(Performance.prototype, "getEntries", {
-                    writeable: true,
-                });
+                for (const propName of [
+                    "getEntries",
+                    "getEntriesByName",
+                    "getEntriesByType",
+                ])
+                    Object.defineProperty(Performance.prototype, propName, {
+                        writable: true,
+                    });
 
                 Performance.prototype.getEntries = noop;
                 Performance.prototype.getEntriesByName = noop;


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Fix issue #441 by fixing a spelling error

#### Background (Problem in detail)  - optional
See #441. Node 18.8 seems to have the `writable` prop of the Performance fields set to `false` by default and our test did incorrectly try to re-configure it.