### PR TITLE
chore: remove `fsevents` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,6 @@
         "mochify": "9.2.0",
         "nyc": "15.1.0",
         "prettier": "2.7.1"
-      },
-      "optionalDependencies": {
-        "fsevents": "*"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3144,6 +3141,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -10119,6 +10117,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "optional": true
     },
     "function-bind": {

--- a/package.json
+++ b/package.json
@@ -50,9 +50,6 @@
   "dependencies": {
     "@sinonjs/commons": "^2.0.0"
   },
-  "optionalDependencies": {
-    "fsevents": "*"
-  },
   "nyc": {
     "branches": 85,
     "lines": 92,


### PR DESCRIPTION
https://github.com/sinonjs/fake-timers/pull/440#discussion_r1030602932