### PR TITLE
Add clock.jump method

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,13 @@ Advances the clock to the the moment of the first scheduled timer, firing it.
 The `nextAsync()` will also break the event loop, allowing any scheduled promise
 callbacks to execute _before_ running the timers.
 
+### `clock.jump(time)`
+
+Advance the clock by jumping forward in time, firing callbacks at most once.
+`time` takes the same formats as [`clock.tick`](#clockticktime--await-clocktickasynctime).
+
+This can be used to simulate the JS engine (such as a browser) being put to sleep and resumed later, skipping intermediary timers.
+
 ### `clock.reset()`
 
 Removes all timers and ticks without firing them, and sets `now` to `config.now`

--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -79,6 +79,7 @@ const globalObject = require("@sinonjs/commons").global;
  * @property {function(): Promise<number>} runToLastAsync
  * @property {function(): void} reset
  * @property {function(number | Date): void} setSystemTime
+ * @property {function(number): void} jump
  * @property {Performance} performance
  * @property {function(number[]): number[]} hrtime - process.hrtime (legacy)
  * @property {function(): void} uninstall Uninstall the clock.
@@ -1603,6 +1604,25 @@ function withGlobal(_global) {
                     timer.callAt += difference;
                 }
             }
+        };
+
+        /**
+         * @param {string|number} tickValue number of milliseconds or a human-readable value like "01:11:15"
+         * @returns {number} will return the new `now` value
+         */
+        clock.jump = function jump(tickValue) {
+            const msFloat =
+                typeof tickValue === "number"
+                    ? tickValue
+                    : parseTime(tickValue);
+            const ms = Math.floor(msFloat);
+
+            for (const timer of Object.values(clock.timers)) {
+                if (clock.now + ms > timer.callAt) {
+                    timer.callAt = clock.now + ms;
+                }
+            }
+            clock.tick(ms);
         };
 
         if (performancePresent) {

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -4123,11 +4123,14 @@ describe("FakeTimers", function () {
 
         it("pushes back execution time for skipped timers", function () {
             const stub = sinon.stub();
-            this.clock.setTimeout(stub, 1000);
+            this.clock.setTimeout(() => {
+                stub(this.clock.Date.now());
+            }, 1000);
 
             this.clock.jump(2000);
 
             assert(stub.calledOnce);
+            assert(stub.calledWith(2000));
         });
 
         it("handles multiple pending timers and types", function () {


### PR DESCRIPTION
#### Purpose (TL;DR)

Closes #452 by creating the `clock.jump(time)` method enabling skipping forward in time and running any timers at most once.