### PR TITLE
feat: mock intl api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+11.1.0 / 2023-07-17
+==================
+  * Add a mock for the global Intl object
+
 11.0.0 / 2023-06-12
 ==================
   * Re-release 10.2.0 as a new major version as mocking Node "timers" module broke some setups

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-
-11.1.0 / 2023-07-17
-==================
-  * Add a mock for the global Intl object
-
 11.0.0 / 2023-06-12
 ==================
   * Re-release 10.2.0 as a new major version as mocking Node "timers" module broke some setups

--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -206,10 +206,6 @@ function withGlobal(_global) {
         _global.clearImmediate = _global.clearImmediate;
     }
 
-    if (intlPresent) {
-        _global.Intl = _global.Intl;
-    }
-
     /* eslint-enable no-self-assign */
 
     _global.clearTimeout(timeoutResult);
@@ -534,8 +530,7 @@ function withGlobal(_global) {
         ClockIntl.DateTimeFormat.prototype = Object.create(
             NativeIntl.DateTimeFormat.prototype
         );
-        ClockIntl.DateTimeFormat.prototype.constructor =
-            ClockIntl.DateTimeFormat;
+
         ClockIntl.DateTimeFormat.supportedLocalesOf =
             NativeIntl.DateTimeFormat.supportedLocalesOf;
 

--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -186,6 +186,7 @@ function withGlobal(_global) {
         typeof _global.cancelIdleCallback === "function";
     const setImmediatePresent =
         _global.setImmediate && typeof _global.setImmediate === "function";
+    const intlPresent = _global.Intl && typeof _global.Intl === "object";
 
     // Make properties writable in IE, as per
     // https://www.adequatelygood.com/Replacing-setTimeout-Globally.html
@@ -204,11 +205,17 @@ function withGlobal(_global) {
         _global.setImmediate = _global.setImmediate;
         _global.clearImmediate = _global.clearImmediate;
     }
+
+    if (intlPresent) {
+        _global.Intl = _global.Intl;
+    }
+
     /* eslint-enable no-self-assign */
 
     _global.clearTimeout(timeoutResult);
 
     const NativeDate = _global.Date;
+    const NativeIntl = _global.Intl;
     let uniqueTimerId = idCounterStart;
 
     /**
@@ -498,6 +505,41 @@ function withGlobal(_global) {
         }
 
         return mirrorDateProperties(ClockDate, NativeDate);
+    }
+
+    //eslint-disable-next-line jsdoc/require-jsdoc
+    function createIntl() {
+        const ClockIntl = { ...NativeIntl };
+
+        ClockIntl.DateTimeFormat = function (...args) {
+            const realFormatter = new NativeIntl.DateTimeFormat(...args);
+            const formatter = {};
+
+            ["formatRange", "formatRangeToParts", "resolvedOptions"].forEach(
+                (method) => {
+                    formatter[method] =
+                        realFormatter[method].bind(realFormatter);
+                }
+            );
+
+            ["format", "formatToParts"].forEach((method) => {
+                formatter[method] = function (date) {
+                    return realFormatter[method](date || ClockIntl.clock.now);
+                };
+            });
+
+            return formatter;
+        };
+
+        ClockIntl.DateTimeFormat.prototype = Object.create(
+            NativeIntl.DateTimeFormat.prototype
+        );
+        ClockIntl.DateTimeFormat.prototype.constructor =
+            ClockIntl.DateTimeFormat;
+        ClockIntl.DateTimeFormat.supportedLocalesOf =
+            NativeIntl.DateTimeFormat.supportedLocalesOf;
+
+        return ClockIntl;
     }
 
     //eslint-disable-next-line jsdoc/require-jsdoc
@@ -934,6 +976,8 @@ function withGlobal(_global) {
         if (method === "Date") {
             const date = mirrorDateProperties(clock[method], target[method]);
             target[method] = date;
+        } else if (method === "Intl") {
+            target[method] = clock[method];
         } else if (method === "performance") {
             const originalPerfDescriptor = Object.getOwnPropertyDescriptor(
                 target,
@@ -988,6 +1032,7 @@ function withGlobal(_global) {
      * @property {setInterval} setInterval
      * @property {clearInterval} clearInterval
      * @property {Date} Date
+     * @property {Intl} Intl
      * @property {SetImmediate=} setImmediate
      * @property {function(NodeImmediate): void=} clearImmediate
      * @property {function(number[]):number[]=} hrtime
@@ -1044,6 +1089,10 @@ function withGlobal(_global) {
 
     if (cancelIdleCallbackPresent) {
         timers.cancelIdleCallback = _global.cancelIdleCallback;
+    }
+
+    if (intlPresent) {
+        timers.Intl = _global.Intl;
     }
 
     const originalSetTimeout = _global.setImmediate || _global.setTimeout;
@@ -1122,6 +1171,11 @@ function withGlobal(_global) {
                 const parts = hrtime();
                 return BigInt(parts[0]) * BigInt(1e9) + BigInt(parts[1]); // eslint-disable-line
             };
+        }
+
+        if (intlPresent) {
+            clock.Intl = createIntl();
+            clock.Intl.clock = clock;
         }
 
         clock.requestIdleCallback = function requestIdleCallback(

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -5292,4 +5292,12 @@ describe("Intl API", function () {
         clock.now = Date.UTC(2022, 5, 1);
         assert.isFalse(isFirstOfMonth("America/Toronto"));
     });
+
+    it("Executes supportedLocalesOf like normal", function () {
+        assert.equals(
+            Intl.DateTimeFormat.supportedLocalesOf(),
+            //eslint-disable-next-line no-underscore-dangle
+            clock._Intl.DateTimeFormat.supportedLocalesOf()
+        );
+    });
 });

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -5179,3 +5179,117 @@ describe("Node Timer: ref(), unref(),hasRef()", function () {
         clock.uninstall();
     });
 });
+
+describe("Intl API", function () {
+    /**
+     * Tester function to check if the globally hijacked Intl object is plugging into the faked Clock
+     *
+     * @param {string} ianaTimeZone - IANA time zone name
+     * @param {number} timestamp - UNIX timestamp
+     * @returns {boolean}
+     */
+    function isFirstOfMonth(ianaTimeZone, timestamp) {
+        return (
+            new Intl.DateTimeFormat(undefined, { timeZone: ianaTimeZone })
+                .formatToParts(timestamp)
+                .find((part) => part.type === "day").value === "1"
+        );
+    }
+
+    let clock;
+
+    before(function () {
+        clock = FakeTimers.install();
+    });
+
+    after(function () {
+        clock.uninstall();
+    });
+
+    it("Executes formatRange like normal", function () {
+        const start = new Date(Date.UTC(2020, 0, 1, 0, 0));
+        const end = new Date(Date.UTC(2020, 0, 1, 0, 1));
+        const options = {
+            timeZone: "UTC",
+            hour12: false,
+            hour: "numeric",
+            minute: "numeric",
+        };
+        assert.equals(
+            new Intl.DateTimeFormat("en-GB", options).formatRange(start, end),
+            "00:00–00:01"
+        );
+    });
+
+    it("Executes formatRangeToParts like normal", function () {
+        const start = new Date(Date.UTC(2020, 0, 1, 0, 0));
+        const end = new Date(Date.UTC(2020, 0, 1, 0, 1));
+        const options = {
+            timeZone: "UTC",
+            hour12: false,
+            hour: "numeric",
+            minute: "numeric",
+        };
+        assert.equals(
+            new Intl.DateTimeFormat("en-GB", options).formatRangeToParts(
+                start,
+                end
+            ),
+            [
+                { type: "hour", value: "00", source: "startRange" },
+                { type: "literal", value: ":", source: "startRange" },
+                { type: "minute", value: "00", source: "startRange" },
+                { type: "literal", value: "–", source: "shared" },
+                { type: "hour", value: "00", source: "endRange" },
+                { type: "literal", value: ":", source: "endRange" },
+                { type: "minute", value: "01", source: "endRange" },
+            ]
+        );
+    });
+
+    it("Executes resolvedOptions like normal", function () {
+        const options = {
+            timeZone: "UTC",
+            hour12: false,
+            hour: "2-digit",
+            minute: "2-digit",
+        };
+        assert.equals(
+            new Intl.DateTimeFormat("en-GB", options).resolvedOptions(),
+            {
+                locale: "en-GB",
+                calendar: "gregory",
+                numberingSystem: "latn",
+                timeZone: "UTC",
+                hour12: false,
+                hourCycle: "h23",
+                hour: "2-digit",
+                minute: "2-digit",
+            }
+        );
+    });
+
+    it("formatToParts via isFirstOfMonth -> Returns true when passed a timestamp argument that is first of the month", function () {
+        // June 1 04:00 UTC - Toronto is June 1 00:00
+        assert.isTrue(
+            isFirstOfMonth("America/Toronto", Date.UTC(2022, 5, 1, 4))
+        );
+    });
+
+    it("formatToParts via isFirstOfMonth -> Returns false when passed a timestamp argument that is not first of the month", function () {
+        // June 1 00:00 UTC - Toronto is May 31 20:00
+        assert.isFalse(isFirstOfMonth("America/Toronto", Date.UTC(2022, 5, 1)));
+    });
+
+    it("formatToParts via isFirstOfMonth -> Returns true when passed no timestamp and system time is first of the month", function () {
+        // June 1 04:00 UTC - Toronto is June 1 00:00
+        clock.now = Date.UTC(2022, 5, 1, 4);
+        assert.isTrue(isFirstOfMonth("America/Toronto"));
+    });
+
+    it("formatToParts via isFirstOfMonth -> Returns false when passed no timestamp and system time is not first of the month", function () {
+        // June 1 00:00 UTC - Toronto is May 31 20:00
+        clock.now = Date.UTC(2022, 5, 1);
+        assert.isFalse(isFirstOfMonth("America/Toronto"));
+    });
+});


### PR DESCRIPTION
#### Purpose (TL;DR) - Mock the global Intl API

Solve the breaking of timer-dependant methods on the Intl global object by including a mocked version

#### Background (Problem in detail)

Even after calling install(), the Intl.DateTimeFormat() class will currently use the real time of the system, not the time specified by the fake clock.

Affected methods: DateTimeFormat.format(), DateTimeFormat.formatToParts()

My repo demonstrating the problem, using Jest (which uses sinonjs/fake-timers): https://github.com/BenIsenstein/jest_fix_intl_fake_timers

The fix works by following the patterns used to mock the global Date class and mocking the Intl object. A producer function is written to return an Intl object largely identical to the original, except for the DateTimeFormat() class. DateTimeFormat has several methods that are time-sensitive, and depend on the system time when no argument is passed. These are intercepted and made to default to the clock time.

```javascript
//eslint-disable-next-line jsdoc/require-jsdoc
function createIntl() {
    const ClockIntl = { ...NativeIntl };

    ClockIntl.DateTimeFormat = function (...args) {
        const realFormatter = new NativeIntl.DateTimeFormat(...args);
        const formatter = {};

        ["formatRange", "formatRangeToParts", "resolvedOptions"].forEach(
            (method) => {
                formatter[method] =
                    realFormatter[method].bind(realFormatter);
            }
        );

        ["format", "formatToParts"].forEach((method) => {
            formatter[method] = function (date) {
                return realFormatter[method](date || ClockIntl.clock.now);
            };
        });

        return formatter;
    };

    ClockIntl.DateTimeFormat.prototype = Object.create(
        NativeIntl.DateTimeFormat.prototype
    );
    ClockIntl.DateTimeFormat.prototype.constructor =
        ClockIntl.DateTimeFormat;
    ClockIntl.DateTimeFormat.supportedLocalesOf =
        NativeIntl.DateTimeFormat.supportedLocalesOf;

    return ClockIntl;
}
```

This fake Intl object is provided to the Global object when install() is called.

Line 1176, inside createClock()
```javascript
if (intlPresent) {
    clock.Intl = createIntl();
    clock.Intl.clock = clock;
}
```

and the original Intl object is restored during uninstall().

Line 979 inside hijackMethod()
An else-if clause added to handle hijacking Intl. Because Intl isn't a straightforward global function, rather a global object used like a module, it can't be mocked using the default else clause at the end of hijackMethod(). It has its own clause to set the mocked Intl object globally. 
```javascript
else if (method === "Intl") {
    target[method] = clock[method];
```

I'm fairly confident on implementation, however less confident on the tests. All advice is appreciated!

Ben
