### PR TITLE
favor the constructor of the performance instance if it exists

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -1752,11 +1752,11 @@ function withGlobal(_global) {
 
         if (clock.methods.includes("performance")) {
             const proto = (() => {
-                if (hasPerformancePrototype) {
-                    return _global.Performance.prototype;
-                }
                 if (hasPerformanceConstructorPrototype) {
                     return _global.performance.constructor.prototype;
+                }
+                if (hasPerformancePrototype) {
+                    return _global.Performance.prototype;
                 }
             })();
             if (proto) {


### PR DESCRIPTION
#### Purpose 

Fix issue #420 by favoring the constructor of the performance instance over the Performance class


#### Background

jsdom also patches the `Performance` class and doesn't implement all of the methods.

I could not use the workaround mentioned: https://github.com/sinonjs/fake-timers/issues/394#issuecomment-1021665619 because I'm using vitest with jsdom as the environment.


#### Solution 

This simply favors the prototype of the performance instance, since that seems to be untouched by jsdom. 
