### PR TITLE
feat: add RelativeTimeFormat to Intl API

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -481,9 +481,24 @@ function withGlobal(_global) {
         return mirrorDateProperties(ClockDate, NativeDate);
     }
 
-    //eslint-disable-next-line jsdoc/require-jsdoc
+    /**
+     * Mirror Intl by default on our fake implementation
+     *
+     * Most of the properties are the original native ones,
+     * but we need to take control of those that have a
+     * dependency on the current clock.
+     *
+     * @returns {object} the partly fake Intl implementation
+     */
     function createIntl() {
-        const ClockIntl = { ...NativeIntl };
+        const ClockIntl = {};
+        /*
+         * All properties of Intl are non-enumerable, so we need
+         * to do a bit of work to get them out.
+         */
+        Object.getOwnPropertyNames(NativeIntl).forEach(
+            (property) => (ClockIntl[property] = NativeIntl[property])
+        );
 
         ClockIntl.DateTimeFormat = function (...args) {
             const realFormatter = new NativeIntl.DateTimeFormat(...args);
@@ -504,8 +519,6 @@ function withGlobal(_global) {
 
             return formatter;
         };
-
-        ClockIntl.RelativeTimeFormat = NativeIntl.RelativeTimeFormat;
 
         ClockIntl.DateTimeFormat.prototype = Object.create(
             NativeIntl.DateTimeFormat.prototype
@@ -1135,6 +1148,17 @@ function withGlobal(_global) {
             return [secsSinceStart, remainderInNanos];
         }
 
+        /**
+         * A high resolution timestamp in milliseconds.
+         *
+         * @typedef {number} DOMHighResTimeStamp
+         */
+
+        /**
+         * performance.now()
+         *
+         * @returns {DOMHighResTimeStamp}
+         */
         function fakePerformanceNow() {
             const hrt = hrtime();
             const millis = hrt[0] * 1000 + hrt[1] / 1e6;

--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -505,6 +505,8 @@ function withGlobal(_global) {
             return formatter;
         };
 
+        ClockIntl.RelativeTimeFormat = NativeIntl.RelativeTimeFormat;
+
         ClockIntl.DateTimeFormat.prototype = Object.create(
             NativeIntl.DateTimeFormat.prototype
         );

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -4688,7 +4688,7 @@ describe("FakeTimers", function () {
          * @template E
          * @param {E[]} [list1]
          * @param {E[]} [list2]
-         * @return {E[]}
+         * @returns {E[]}
          */
         function getIntersection(list1, list2) {
             return list1.filter((value) => list2.indexOf(value) !== -1);
@@ -4699,7 +4699,7 @@ describe("FakeTimers", function () {
          *
          * @function
          * @param {string[]} [toFake]
-         * @return {{propertyName: string, originalValue: any}[]}
+         * @returns {{propertyName: string, originalValue: any}[]}
          */
         function getOriginals(toFake) {
             return toFake.map((propertyName) => ({
@@ -5302,6 +5302,10 @@ describe("Intl API", function () {
     });
 
     it("Creates a RelativeTimeFormat like normal", function () {
+        if (typeof Intl?.RelativeTimeFormat === "undefined") {
+            this.skip();
+        }
+
         const rtf = new Intl.RelativeTimeFormat("en-GB", {
             numeric: "auto",
         });

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -5300,4 +5300,11 @@ describe("Intl API", function () {
             clock._Intl.DateTimeFormat.supportedLocalesOf()
         );
     });
+
+    it("Creates a RelativeTimeFormat like normal", function () {
+        const rtf = new Intl.RelativeTimeFormat("en-GB", {
+            numeric: "auto",
+        });
+        assert.equals(rtf.format(2, "day"), "in 2 days");
+    });
 });


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

PR #474 has introduced a mock for the intl API, and this has introduced a regression for me, where I'm not able to call `Intl.RelativeTimeFormat`.

#### Background (Problem in detail)
The problem showed in some of my test cases, once I updated `fake-timers`, when trying to use `Intl.RelativeTimeFormat` I got the following error: `Intl.RelativeTimeFormat is not a constructor`

#### Solution
The solution I opted for is to assign `RelativeTimeFormat` to the mocked `Intl` API with.
```js
ClockIntl.RelativeTimeFormat = NativeIntl.RelativeTimeFormat;
```