### PR TITLE
fixes invalid use of arguments in strict mode error

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -28,14 +28,14 @@ if (typeof require === "function" && typeof module === "object") {
 /**
  * @callback NextTick
  * @param {VoidVarArgsFunc} callback - the callback to run
- * @param {...*} arguments - optional arguments to call the callback with
+ * @param {...*} args - optional arguments to call the callback with
  * @returns {void}
  */
 
 /**
  * @callback SetImmediate
  * @param {VoidVarArgsFunc} callback - the callback to run
- * @param {...*} arguments - optional arguments to call the callback with
+ * @param {...*} args - optional arguments to call the callback with
  * @returns {NodeImmediate}
  */
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Fix typescript error T1100 which complains about invalid use of term 'arguments' in strict mode.

#### Solution  - optional

Use args instead of arguments in annotation.

<img width="634" alt="Näyttökuva 2023-10-18 133619" src="https://github.com/sinonjs/fake-timers/assets/3228613/cdc297d1-e455-4d77-8c2a-ef28d1337959">
<img width="628" alt="Näyttökuva 2023-10-18 133446" src="https://github.com/sinonjs/fake-timers/assets/3228613/a0dcf7d7-cc32-4ad5-a7c2-6328534cb064">
