### PR TITLE
Fix link to Mochify and adjust description

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,8 +349,8 @@ $(npm bin)/mocha ./test/fake-timers-test.js
 
 ### In the browser
 
-[Mochify](https://github.com/mantoni/mochify.js) is used to run the tests in
-PhantomJS. Make sure you have `phantomjs` installed. Then:
+[Mochify](https://github.com/mochify-js) is used to run the tests in headless
+Chrome.
 
 ```sh
 npm test-headless


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Mochify became an org with the rewrite and the description was still referring to PhantomJS.

