### PR TITLE
Fail when a timer is not available in the context

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -110,18 +110,6 @@ if (typeof require === "function" && typeof module === "object") {
  * @property {boolean} [ignoreMissingTimers] default is false, meaning asking to fake timers that are not present will throw an error
  */
 
-/**
- * Map of the potential timers/objects to fake and their presence in the passed in global
- *
- * @typedef {object} TimerPresenceMap
- * @property {boolean} performance whether or not global.performance is there
- * @property {boolean} setTimeout  is setTimeout present
- * @property {boolean} setImmediate is setImmediate present
- * @property {boolean} hrtime is 'hrtime' present
- * @property {boolean} hrtimeBigint is 'hrtimeBigint' present
- * @property {boolean} queueMicrotask  is 'queueMicrotask' present
- */
-
 /* eslint-disable jsdoc/require-property-description */
 /**
  * The internal structure to describe a scheduled fake timer
@@ -164,7 +152,6 @@ function withGlobal(_global) {
     const NOOP_ARRAY = function () {
         return [];
     };
-    /** @type {TimerPresenceMap} */
     const isPresent = {};
     let timeoutResult,
         addTimerReturnsObject = false;

--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -107,6 +107,19 @@ if (typeof require === "function" && typeof module === "object") {
  * @property {boolean} [shouldAdvanceTime] tells FakeTimers to increment mocked time automatically (default false)
  * @property {number} [advanceTimeDelta] increment mocked time every <<advanceTimeDelta>> ms (default: 20ms)
  * @property {boolean} [shouldClearNativeTimers] forwards clear timer calls to native functions if they are not fakes (default: false)
+ * @property {boolean} [ignoreMissingTimers] default is false, meaning asking to fake timers that are not present will throw an error
+ */
+
+/**
+ * Map of the potential timers/objects to fake and their presence in the passed in global
+ *
+ * @typedef {object} TimerPresenceMap
+ * @property {boolean} performance whether or not global.performance is there
+ * @property {boolean} setTimeout  is setTimeout present
+ * @property {boolean} setImmediate is setImmediate present
+ * @property {boolean} hrtime is 'hrtime' present
+ * @property {boolean} hrtimeBigint is 'hrtimeBigint' present
+ * @property {boolean} queueMicrotask  is 'queueMicrotask' present
  */
 
 /* eslint-disable jsdoc/require-property-description */
@@ -151,16 +164,27 @@ function withGlobal(_global) {
     const NOOP_ARRAY = function () {
         return [];
     };
-    const timeoutResult = _global.setTimeout(NOOP, 0);
-    const addTimerReturnsObject = typeof timeoutResult === "object";
-    const hrtimePresent =
+    /** @type {TimerPresenceMap} */
+    const isPresent = {};
+    let timeoutResult,
+        addTimerReturnsObject = false;
+
+    if (_global.setTimeout) {
+        isPresent.setTimeout = true;
+        timeoutResult = _global.setTimeout(NOOP, 0);
+        addTimerReturnsObject = typeof timeoutResult === "object";
+    }
+    isPresent.clearTimeout = Boolean(_global.clearTimeout);
+    isPresent.setInterval = Boolean(_global.setInterval);
+    isPresent.clearInterval = Boolean(_global.clearInterval);
+    isPresent.hrtime =
         _global.process && typeof _global.process.hrtime === "function";
-    const hrtimeBigintPresent =
-        hrtimePresent && typeof _global.process.hrtime.bigint === "function";
-    const nextTickPresent =
+    isPresent.hrtimeBigint =
+        isPresent.hrtime && typeof _global.process.hrtime.bigint === "function";
+    isPresent.nextTick =
         _global.process && typeof _global.process.nextTick === "function";
     const utilPromisify = _global.process && require("util").promisify;
-    const performancePresent =
+    isPresent.performance =
         _global.performance && typeof _global.performance.now === "function";
     const hasPerformancePrototype =
         _global.Performance &&
@@ -169,28 +193,40 @@ function withGlobal(_global) {
         _global.performance &&
         _global.performance.constructor &&
         _global.performance.constructor.prototype;
-    const queueMicrotaskPresent = _global.hasOwnProperty("queueMicrotask");
-    const requestAnimationFramePresent =
+    isPresent.queueMicrotask = _global.hasOwnProperty("queueMicrotask");
+    isPresent.requestAnimationFrame =
         _global.requestAnimationFrame &&
         typeof _global.requestAnimationFrame === "function";
-    const cancelAnimationFramePresent =
+    isPresent.cancelAnimationFrame =
         _global.cancelAnimationFrame &&
         typeof _global.cancelAnimationFrame === "function";
-    const requestIdleCallbackPresent =
+    isPresent.requestIdleCallback =
         _global.requestIdleCallback &&
         typeof _global.requestIdleCallback === "function";
-    const cancelIdleCallbackPresent =
+    isPresent.cancelIdleCallbackPresent =
         _global.cancelIdleCallback &&
         typeof _global.cancelIdleCallback === "function";
-    const setImmediatePresent =
+    isPresent.setImmediate =
         _global.setImmediate && typeof _global.setImmediate === "function";
-    const intlPresent = _global.Intl && typeof _global.Intl === "object";
+    isPresent.clearImmediate =
+        _global.clearImmediate && typeof _global.clearImmediate === "function";
+    isPresent.Intl = _global.Intl && typeof _global.Intl === "object";
 
-    _global.clearTimeout(timeoutResult);
+    if (_global.clearTimeout) {
+        _global.clearTimeout(timeoutResult);
+    }
 
     const NativeDate = _global.Date;
     const NativeIntl = _global.Intl;
     let uniqueTimerId = idCounterStart;
+
+    if (NativeDate === undefined) {
+        throw new Error(
+            "The global scope doesn't have a `Date` object" +
+                " (see https://github.com/sinonjs/sinon/issues/1852#issuecomment-419622780)",
+        );
+    }
+    isPresent.Date = true;
 
     /**
      * @param {number} num
@@ -1042,44 +1078,44 @@ function withGlobal(_global) {
         Date: _global.Date,
     };
 
-    if (setImmediatePresent) {
+    if (isPresent.setImmediate) {
         timers.setImmediate = _global.setImmediate;
         timers.clearImmediate = _global.clearImmediate;
     }
 
-    if (hrtimePresent) {
+    if (isPresent.hrtime) {
         timers.hrtime = _global.process.hrtime;
     }
 
-    if (nextTickPresent) {
+    if (isPresent.nextTick) {
         timers.nextTick = _global.process.nextTick;
     }
 
-    if (performancePresent) {
+    if (isPresent.performance) {
         timers.performance = _global.performance;
     }
 
-    if (requestAnimationFramePresent) {
+    if (isPresent.requestAnimationFrame) {
         timers.requestAnimationFrame = _global.requestAnimationFrame;
     }
 
-    if (queueMicrotaskPresent) {
+    if (isPresent.queueMicrotask) {
         timers.queueMicrotask = true;
     }
 
-    if (cancelAnimationFramePresent) {
+    if (isPresent.cancelAnimationFrame) {
         timers.cancelAnimationFrame = _global.cancelAnimationFrame;
     }
 
-    if (requestIdleCallbackPresent) {
+    if (isPresent.requestIdleCallback) {
         timers.requestIdleCallback = _global.requestIdleCallback;
     }
 
-    if (cancelIdleCallbackPresent) {
+    if (isPresent.cancelIdleCallback) {
         timers.cancelIdleCallback = _global.cancelIdleCallback;
     }
 
-    if (intlPresent) {
+    if (isPresent.Intl) {
         timers.Intl = _global.Intl;
     }
 
@@ -1097,13 +1133,6 @@ function withGlobal(_global) {
         loopLimit = loopLimit || 1000;
         let nanos = 0;
         const adjustedSystemTime = [0, 0]; // [millis, nanoremainder]
-
-        if (NativeDate === undefined) {
-            throw new Error(
-                "The global scope doesn't have a `Date` object" +
-                    " (see https://github.com/sinonjs/sinon/issues/1852#issuecomment-419622780)",
-            );
-        }
 
         const clock = {
             now: start,
@@ -1165,14 +1194,14 @@ function withGlobal(_global) {
             return millis;
         }
 
-        if (hrtimeBigintPresent) {
+        if (isPresent.hrtimeBigint) {
             hrtime.bigint = function () {
                 const parts = hrtime();
                 return BigInt(parts[0]) * BigInt(1e9) + BigInt(parts[1]); // eslint-disable-line
             };
         }
 
-        if (intlPresent) {
+        if (isPresent.Intl) {
             clock.Intl = createIntl();
             clock.Intl.clock = clock;
         }
@@ -1257,7 +1286,7 @@ function withGlobal(_global) {
             return clearTimer(clock, timerId, "Interval");
         };
 
-        if (setImmediatePresent) {
+        if (isPresent.setImmediate) {
             clock.setImmediate = function setImmediate(func) {
                 return addTimer(clock, {
                     func: func,
@@ -1696,12 +1725,12 @@ function withGlobal(_global) {
             clock.tick(ms);
         };
 
-        if (performancePresent) {
+        if (isPresent.performance) {
             clock.performance = Object.create(null);
             clock.performance.now = fakePerformanceNow;
         }
 
-        if (hrtimePresent) {
+        if (isPresent.hrtime) {
             clock.hrtime = hrtime;
         }
 
@@ -1746,6 +1775,20 @@ function withGlobal(_global) {
         if (config.target) {
             throw new TypeError(
                 "config.target is no longer supported. Use `withGlobal(target)` instead.",
+            );
+        }
+
+        /**
+         * @param {string} timer/object the name of the thing that is not present
+         * @param timer
+         */
+        function handleMissingTimer(timer) {
+            if (config.ignoreMissingTimers) {
+                return;
+            }
+
+            throw new ReferenceError(
+                `non-existent timers and/or objects cannot be faked: '${timer}'`,
             );
         }
 
@@ -1798,10 +1841,7 @@ function withGlobal(_global) {
                     }
                 });
             } else if ((config.toFake || []).includes("performance")) {
-                // user explicitly tried to fake performance when not present
-                throw new ReferenceError(
-                    "non-existent performance object cannot be faked",
-                );
+                return handleMissingTimer("performance");
             }
         }
         if (_global === globalObject && timersModule) {
@@ -1809,6 +1849,13 @@ function withGlobal(_global) {
         }
         for (i = 0, l = clock.methods.length; i < l; i++) {
             const nameOfMethodToReplace = clock.methods[i];
+
+            if (!isPresent[nameOfMethodToReplace]) {
+                handleMissingTimer(nameOfMethodToReplace);
+                // eslint-disable-next-line
+                continue;
+            }
+
             if (nameOfMethodToReplace === "hrtime") {
                 if (
                     _global.process &&

--- a/test/issue-1852-test.js
+++ b/test/issue-1852-test.js
@@ -4,15 +4,11 @@ const { FakeTimers, assert } = require("./helpers/setup-tests");
 
 describe("issue sinon#1852", function () {
     it("throws when creating a clock and global has no Date", function () {
-        const clock = FakeTimers.withGlobal({
-            setTimeout: function () {},
-            clearTimeout: function () {},
-        });
         assert.exception(function () {
-            clock.createClock();
-        });
-        assert.exception(function () {
-            clock.install();
+            FakeTimers.withGlobal({
+                setTimeout: function () {},
+                clearTimeout: function () {},
+            });
         });
     });
 });

--- a/test/issue-2449-test.js
+++ b/test/issue-2449-test.js
@@ -21,20 +21,25 @@ describe("issue #2449: permanent loss of native functions", function () {
     });
 
     it("should not fake faked timers on a custom target", function () {
-        const setTimeoutFake = sinon.fake();
         const context = {
             Date: Date,
-            setTimeout: setTimeoutFake,
+            setTimeout: sinon.fake(),
             clearTimeout: sinon.fake(),
         };
-        let clock = FakeTimers.withGlobal(context).install();
+        let clock = FakeTimers.withGlobal(context).install({
+            ignoreMissingTimers: true,
+        });
         assert.exception(function () {
-            clock = FakeTimers.withGlobal(context).install();
+            clock = FakeTimers.withGlobal(context).install({
+                ignoreMissingTimers: true,
+            });
         });
         clock.uninstall();
 
         // After uninstaling we should be able to install without issue
-        clock = FakeTimers.withGlobal(context).install();
+        clock = FakeTimers.withGlobal(context).install({
+            ignoreMissingTimers: true,
+        });
         clock.uninstall();
     });
 
@@ -49,7 +54,9 @@ describe("issue #2449: permanent loss of native functions", function () {
         };
         assert.equals(new context.Date().getTime(), 0);
         assert.exception(function () {
-            FakeTimers.withGlobal(context).install();
+            FakeTimers.withGlobal(context).install({
+                ignoreMissingTimers: true,
+            });
         });
 
         globalClock.uninstall();
@@ -63,7 +70,9 @@ describe("issue #2449: permanent loss of native functions", function () {
             setTimeout: setTimeoutFake,
             clearTimeout: sinon.fake(),
         };
-        const clock = FakeTimers.withGlobal(context).install();
+        const clock = FakeTimers.withGlobal(context).install({
+            ignoreMissingTimers: true,
+        });
         assert.equals(new context.Date().getTime(), 0);
         refute.equals(new Date().getTime(), 0);
         const globalClock = FakeTimers.install();

--- a/test/issue-59-test.js
+++ b/test/issue-59-test.js
@@ -10,7 +10,9 @@ describe("issue #59", function () {
             setTimeout: setTimeoutFake,
             clearTimeout: sinon.fake(),
         };
-        const clock = FakeTimers.withGlobal(context).install();
+        const clock = FakeTimers.withGlobal(context).install({
+            ignoreMissingTimers: true,
+        });
         assert.equals(setTimeoutFake.callCount, 1);
         clock.setTimeout(NOOP, 0);
         assert.equals(setTimeoutFake.callCount, 1);


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
fix #490

This makes FakeTimers stricter by failing when trying to fake
a timer or object that is not present on the (chosen) global object.

To make transitioning easier, we provide a flag to revert to the
behavior where missing timers were (mostly) ignored.


<!--
> give a concise (one or two short sentences) description of what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->

#### Background (Problem in detail)  - optional
See #490
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->

<!--
#### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->
