### PR TITLE
Add support for timers/promises module from nodejs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ clock instance, not the browser's internals.
 
 Calling `install` with no arguments achieves this. You can call `uninstall`
 later to restore things as they were again.
-Note that in NodeJS also the [timers](https://nodejs.org/api/timers.html) module will receive fake timers when using global scope.
+Note that in NodeJS the [timers](https://nodejs.org/api/timers.html) and [timers/promises](https://nodejs.org/api/timers.html#timers-promises-api) modules will also receive fake timers when using global scope.
 
 ```js
 // In the browser distribution, a global `FakeTimers` is already available
@@ -148,7 +148,7 @@ The `loopLimit` argument sets the maximum number of timers that will be run when
 ### `var clock = FakeTimers.install([config])`
 
 Installs FakeTimers using the specified config (otherwise with epoch `0` on the global scope).
-Note that in NodeJS also the [timers](https://nodejs.org/api/timers.html) module will receive fake timers when using global scope.
+Note that in NodeJS the [timers](https://nodejs.org/api/timers.html) and [timers/promises](https://nodejs.org/api/timers.html#timers-promises-api) modules will also receive fake timers when using global scope.
 The following configuration options are available
 
 | Parameter                        | Type        | Default                                                                                                                                                                                                                        | Description                                                                                                                                                                                                                                                                                  |

--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -1917,25 +1917,21 @@ function withGlobal(_global) {
                             };
 
                             const handle = clock.setTimeout(() => {
-                                if (options.signal) {
-                                    options.signal.removeEventListener(
-                                        "abort",
-                                        abort,
-                                    );
-                                }
+                                options.signal?.removeEventListener(
+                                    "abort",
+                                    abort,
+                                );
 
                                 resolve(value);
                             }, delay);
 
-                            if (options.signal) {
-                                if (options.signal.aborted) {
-                                    abort();
-                                } else {
-                                    options.signal.addEventListener(
-                                        "abort",
-                                        abort,
-                                    );
-                                }
+                            if (options.signal?.aborted) {
+                                abort();
+                            } else {
+                                options.signal?.addEventListener(
+                                    "abort",
+                                    abort,
+                                );
                             }
                         });
                 } else if (nameOfMethodToReplace === "setImmediate") {
@@ -1959,25 +1955,21 @@ function withGlobal(_global) {
                             };
 
                             const handle = clock.setImmediate(() => {
-                                if (options.signal) {
-                                    options.signal.removeEventListener(
-                                        "abort",
-                                        abort,
-                                    );
-                                }
+                                options.signal?.removeEventListener(
+                                    "abort",
+                                    abort,
+                                );
 
                                 resolve(value);
                             });
 
-                            if (options.signal) {
-                                if (options.signal.aborted) {
-                                    abort();
-                                } else {
-                                    options.signal.addEventListener(
-                                        "abort",
-                                        abort,
-                                    );
-                                }
+                            if (options.signal?.aborted) {
+                                abort();
+                            } else {
+                                options.signal?.addEventListener(
+                                    "abort",
+                                    abort,
+                                );
                             }
                         });
                 } else if (nameOfMethodToReplace === "setInterval") {
@@ -2029,27 +2021,20 @@ function withGlobal(_global) {
                                 }
                             };
 
-                            if (options.signal) {
-                                if (options.signal.aborted) {
-                                    done = true;
-                                } else {
-                                    options.signal.addEventListener(
-                                        "abort",
-                                        abort,
-                                    );
-                                }
+                            if (options.signal?.aborted) {
+                                done = true;
+                            } else {
+                                options.signal?.addEventListener(
+                                    "abort",
+                                    abort,
+                                );
                             }
 
                             return {
                                 next: async () => {
-                                    if (options.signal) {
-                                        if (
-                                            options.signal.aborted &&
-                                            !hasThrown
-                                        ) {
-                                            hasThrown = true;
-                                            throw options.signal.reason;
-                                        }
+                                    if (options.signal?.aborted && !hasThrown) {
+                                        hasThrown = true;
+                                        throw options.signal.reason;
                                     }
 
                                     if (done) {
@@ -2070,14 +2055,9 @@ function withGlobal(_global) {
                                         returnCall.resolve();
                                     }
 
-                                    if (options.signal) {
-                                        if (
-                                            options.signal.aborted &&
-                                            !hasThrown
-                                        ) {
-                                            hasThrown = true;
-                                            throw options.signal.reason;
-                                        }
+                                    if (options.signal?.aborted && !hasThrown) {
+                                        hasThrown = true;
+                                        throw options.signal.reason;
                                     }
 
                                     if (done) {
@@ -2099,12 +2079,10 @@ function withGlobal(_global) {
                                     clock.clearInterval(handle);
                                     done = true;
 
-                                    if (options.signal) {
-                                        options.signal.removeEventListener(
-                                            "abort",
-                                            abort,
-                                        );
-                                    }
+                                    options.signal?.removeEventListener(
+                                        "abort",
+                                        abort,
+                                    );
 
                                     return { done: true, value: undefined };
                                 },

--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -1,10 +1,15 @@
 "use strict";
 
 const globalObject = require("@sinonjs/commons").global;
-let timersModule;
+let timersModule, timersPromisesModule;
 if (typeof require === "function" && typeof module === "object") {
     try {
         timersModule = require("timers");
+    } catch (e) {
+        // ignored
+    }
+    try {
+        timersPromisesModule = require("timers/promises");
     } catch (e) {
         // ignored
     }
@@ -94,6 +99,7 @@ if (typeof require === "function" && typeof module === "object") {
  * @property {Function[]} methods - the methods that are faked
  * @property {boolean} [shouldClearNativeTimers] inherited from config
  * @property {{methodName:string, original:any}[] | undefined} timersModuleMethods
+ * @property {{methodName:string, original:any}[] | undefined} timersPromisesModuleMethods
  */
 /* eslint-enable jsdoc/require-property-description */
 
@@ -952,6 +958,16 @@ function withGlobal(_global) {
                 for (let j = 0; j < clock.timersModuleMethods.length; j++) {
                     const entry = clock.timersModuleMethods[j];
                     timersModule[entry.methodName] = entry.original;
+                }
+            }
+            if (clock.timersPromisesModuleMethods !== undefined) {
+                for (
+                    let j = 0;
+                    j < clock.timersPromisesModuleMethods.length;
+                    j++
+                ) {
+                    const entry = clock.timersPromisesModuleMethods[j];
+                    timersPromisesModule[entry.methodName] = entry.original;
                 }
             }
         }
@@ -1834,6 +1850,9 @@ function withGlobal(_global) {
         if (_global === globalObject && timersModule) {
             clock.timersModuleMethods = [];
         }
+        if (_global === globalObject && timersPromisesModule) {
+            clock.timersPromisesModuleMethods = [];
+        }
         for (i = 0, l = clock.methods.length; i < l; i++) {
             const nameOfMethodToReplace = clock.methods[i];
 
@@ -1871,6 +1890,228 @@ function withGlobal(_global) {
                 });
                 timersModule[nameOfMethodToReplace] =
                     _global[nameOfMethodToReplace];
+            }
+            if (clock.timersPromisesModuleMethods !== undefined) {
+                if (nameOfMethodToReplace === "setTimeout") {
+                    clock.timersPromisesModuleMethods.push({
+                        methodName: "setTimeout",
+                        original: timersPromisesModule.setTimeout,
+                    });
+
+                    timersPromisesModule.setTimeout = (
+                        delay,
+                        value,
+                        options = {},
+                    ) =>
+                        new Promise((resolve, reject) => {
+                            const abort = () => {
+                                options.signal.removeEventListener(
+                                    "abort",
+                                    abort,
+                                );
+                                // This is safe, there is no code path that leads to this function
+                                // being invoked before handle has been assigned.
+                                // eslint-disable-next-line no-use-before-define
+                                clock.clearTimeout(handle);
+                                reject(options.signal.reason);
+                            };
+
+                            const handle = clock.setTimeout(() => {
+                                if (options.signal) {
+                                    options.signal.removeEventListener(
+                                        "abort",
+                                        abort,
+                                    );
+                                }
+
+                                resolve(value);
+                            }, delay);
+
+                            if (options.signal) {
+                                if (options.signal.aborted) {
+                                    abort();
+                                } else {
+                                    options.signal.addEventListener(
+                                        "abort",
+                                        abort,
+                                    );
+                                }
+                            }
+                        });
+                } else if (nameOfMethodToReplace === "setImmediate") {
+                    clock.timersPromisesModuleMethods.push({
+                        methodName: "setImmediate",
+                        original: timersPromisesModule.setImmediate,
+                    });
+
+                    timersPromisesModule.setImmediate = (value, options = {}) =>
+                        new Promise((resolve, reject) => {
+                            const abort = () => {
+                                options.signal.removeEventListener(
+                                    "abort",
+                                    abort,
+                                );
+                                // This is safe, there is no code path that leads to this function
+                                // being invoked before handle has been assigned.
+                                // eslint-disable-next-line no-use-before-define
+                                clock.clearImmediate(handle);
+                                reject(options.signal.reason);
+                            };
+
+                            const handle = clock.setImmediate(() => {
+                                if (options.signal) {
+                                    options.signal.removeEventListener(
+                                        "abort",
+                                        abort,
+                                    );
+                                }
+
+                                resolve(value);
+                            });
+
+                            if (options.signal) {
+                                if (options.signal.aborted) {
+                                    abort();
+                                } else {
+                                    options.signal.addEventListener(
+                                        "abort",
+                                        abort,
+                                    );
+                                }
+                            }
+                        });
+                } else if (nameOfMethodToReplace === "setInterval") {
+                    clock.timersPromisesModuleMethods.push({
+                        methodName: "setInterval",
+                        original: timersPromisesModule.setInterval,
+                    });
+
+                    timersPromisesModule.setInterval = (
+                        delay,
+                        value,
+                        options = {},
+                    ) => ({
+                        [Symbol.asyncIterator]: () => {
+                            const createResolvable = () => {
+                                let resolve, reject;
+                                const promise = new Promise((res, rej) => {
+                                    resolve = res;
+                                    reject = rej;
+                                });
+                                promise.resolve = resolve;
+                                promise.reject = reject;
+                                return promise;
+                            };
+
+                            let done = false;
+                            let hasThrown = false;
+                            let returnCall;
+                            let nextAvailable = 0;
+                            const nextQueue = [];
+
+                            const handle = clock.setInterval(() => {
+                                if (nextQueue.length > 0) {
+                                    nextQueue.shift().resolve();
+                                } else {
+                                    nextAvailable++;
+                                }
+                            }, delay);
+
+                            const abort = () => {
+                                options.signal.removeEventListener(
+                                    "abort",
+                                    abort,
+                                );
+                                clock.clearInterval(handle);
+                                done = true;
+                                for (const resolvable of nextQueue) {
+                                    resolvable.resolve();
+                                }
+                            };
+
+                            if (options.signal) {
+                                if (options.signal.aborted) {
+                                    done = true;
+                                } else {
+                                    options.signal.addEventListener(
+                                        "abort",
+                                        abort,
+                                    );
+                                }
+                            }
+
+                            return {
+                                next: async () => {
+                                    if (options.signal) {
+                                        if (
+                                            options.signal.aborted &&
+                                            !hasThrown
+                                        ) {
+                                            hasThrown = true;
+                                            throw options.signal.reason;
+                                        }
+                                    }
+
+                                    if (done) {
+                                        return { done: true, value: undefined };
+                                    }
+
+                                    if (nextAvailable > 0) {
+                                        nextAvailable--;
+                                        return { done: false, value: value };
+                                    }
+
+                                    const resolvable = createResolvable();
+                                    nextQueue.push(resolvable);
+
+                                    await resolvable;
+
+                                    if (returnCall && nextQueue.length === 0) {
+                                        returnCall.resolve();
+                                    }
+
+                                    if (options.signal) {
+                                        if (
+                                            options.signal.aborted &&
+                                            !hasThrown
+                                        ) {
+                                            hasThrown = true;
+                                            throw options.signal.reason;
+                                        }
+                                    }
+
+                                    if (done) {
+                                        return { done: true, value: undefined };
+                                    }
+
+                                    return { done: false, value: value };
+                                },
+                                return: async () => {
+                                    if (done) {
+                                        return { done: true, value: undefined };
+                                    }
+
+                                    if (nextQueue.length > 0) {
+                                        returnCall = createResolvable();
+                                        await returnCall;
+                                    }
+
+                                    clock.clearInterval(handle);
+                                    done = true;
+
+                                    if (options.signal) {
+                                        options.signal.removeEventListener(
+                                            "abort",
+                                            abort,
+                                        );
+                                    }
+
+                                    return { done: true, value: undefined };
+                                },
+                            };
+                        },
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
#### Purpose (TL;DR)

Fix issue #469 by implementing promise-based wrappers around setTimeout, setImmediate, and setInterval.

#### Solution
This PR takes a similar approach to #467 by @swenzel-arc of detecting the availability of the `timers/promises` module by attempting to import it and then overwriting the functions on the import object, which should be the same object users have, given they do not mess with the module cache. Like the aforementioned PR, the functions are only overwritten when calling `install()` on the `globalObject`.

#### Limitations
* When aborting a timer using an `AbortSignal`, the error thrown is not the same as the one thrown by node. This is due to the `AbortError` error being publicly available. See this [issue](https://github.com/nodejs/node/issues/38361).
* This PR does not touch [scheduler.wait](https://nodejs.org/api/timers.html#timerspromisesschedulerwaitdelay-options) or [scheduler.yield](https://nodejs.org/api/timers.html#timerspromisesscheduleryield) of the `timers/promises` module as they are marked as experimental.
