### PR TITLE
Fix toString() output

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -456,6 +456,10 @@ function withGlobal(_global) {
             };
         }
 
+        ClockDate.toString = function toString() {
+            return NativeDate.toString();
+        };
+
         // noinspection UnnecessaryLocalVariableJS
         /**
          * A normal Class constructor cannot be called without `new`, but Date can, so we need

--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -1057,6 +1057,9 @@ function withGlobal(_global) {
 
     if (isPresent.setImmediate) {
         timers.setImmediate = _global.setImmediate;
+    }
+
+    if (isPresent.clearImmediate) {
         timers.clearImmediate = _global.clearImmediate;
     }
 
@@ -1077,7 +1080,7 @@ function withGlobal(_global) {
     }
 
     if (isPresent.queueMicrotask) {
-        timers.queueMicrotask = true;
+        timers.queueMicrotask = _global.queueMicrotask;
     }
 
     if (isPresent.cancelAnimationFrame) {

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -6069,12 +6069,18 @@ describe("missing timers", function () {
         });
 
         it(`should ignore timers in toFake that are not present in "global" when passed the ignore flag: [${timer}]`, function () {
-            //refute.exception(function () {
             FakeTimers.withGlobal({ Date }).install({
                 ignoreMissingTimers: true,
                 toFake: [timer],
             });
-            //});
         });
+    });
+
+    it("should throw on trying to use standard timers that are not present on the custom global", function () {
+        assert.exception(function () {
+            FakeTimers.withGlobal({ setTimeout, Date }).install({
+                toFake: ["setInterval"],
+            });
+        }, /cannot be faked: 'setInterval'/);
     });
 });

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -3358,8 +3358,8 @@ describe("FakeTimers", function () {
             });
         });
 
-        it("mirrors toString", function () {
-            assert.same(this.clock.Date.toString, Date.toString);
+        it("mirrors toString output", function () {
+            assert.same(this.clock.Date.toString(), Date.toString());
         });
     });
 


### PR DESCRIPTION
The output when just inheriting was
function() { [native code] }
vs
function Date() { [native code] }
in the real Date object.

I had to make a choice between having the same function identity and function output and opted for the latter,
since that is what the mother sinon project targets.

#### Purpose (TL;DR) - mandatory

<!--
> give a concise (one or two short sentences) description of what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->

<!--
#### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->

<!--
#### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->
