### PR TITLE
Fix constructor-based checks for fake Date no longer pass after installing

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -450,7 +450,7 @@ function withGlobal(_global) {
 
                 // ensures identity checks using the constructor prop still works
                 // this should have no other functional effect
-                this.constructor = Date;
+                this.constructor = NativeDate;
             }
 
             static [Symbol.hasInstance](instance) {

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -3203,6 +3203,9 @@ describe("FakeTimers", function () {
         // issue #510
         it("creates Date objects where the constructor prop matches the original", function () {
             const realDate = new Date();
+            Date = NOOP; // eslint-disable-line no-global-assign
+            global.Date = NOOP;
+
             const date = new this.clock.Date();
 
             assert.equals(date.constructor.name, realDate.constructor.name);


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fixes #511 (fix for #510) no longer working after the clock had been installed and global `Date` assigned to the fake.

<!--
> give a concise (one or two short sentences) description of what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->

#### Background (Problem in detail)  - optional
Once `ClockDateProxy` was installed to global `Date` (to my surprise) the constructor reference on it was 'updated' to point to `ClockDateProxy`.
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->

<!--
#### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

Thanks again for the help!
