### PR TITLE
Ensure checks based Object.keys length pass for fake Dates

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -450,7 +450,10 @@ function withGlobal(_global) {
 
                 // ensures identity checks using the constructor prop still works
                 // this should have no other functional effect
-                this.constructor = NativeDate;
+                Object.defineProperty(this, "constructor", {
+                    value: NativeDate,
+                    enumerable: false,
+                });
             }
 
             static [Symbol.hasInstance](instance) {

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -3212,6 +3212,12 @@ describe("FakeTimers", function () {
             assert.equals(date.constructor, realDate.constructor);
         });
 
+        it("creates Date objects where the constructor prop is not enumerable", function () {
+            const date = new this.clock.Date();
+
+            assert.equals(Object.keys(date).length, 0);
+        });
+
         it("creates Date objects representing clock time", function () {
             const date = new this.clock.Date();
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fixes sinon.match / samsam equality checks failing between `Date` and fake dates.

<!--
> give a concise (one or two short sentences) description of what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->

#### Background
Ran into another small issue with the constructor: samsam's `deepEqual` [checks the number](https://github.com/sinonjs/samsam/blob/1b141a7cb9d54b0d8a1f20812c2db4bc1f1e53a3/lib/deep-equal.js#L154) of properties on the object, and the constructor [should not be enumerable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor) so there should be 0 keys, but fake Dates had one now.

<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->

<!--
#### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->
