### PR TITLE
fix: return fake version for `performance.timeOrigin`

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -1849,9 +1849,7 @@ function withGlobal(_global) {
                 clock.performance.measure = (name) =>
                     new FakePerformanceEntry(name, "measure", 0, 100);
                 // ensure `timeOrigin` returns a valid value
-                clock.performance.timeOrigin = config.now
-                    ? getEpoch(config.now)
-                    : new Date().getTime();
+                clock.performance.timeOrigin = getEpoch(config.now);
             } else if ((config.toFake || []).includes("performance")) {
                 return handleMissingTimer("performance");
             }

--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -23,7 +23,6 @@ if (typeof require === "function" && typeof module === "object") {
 
 /**
  * Queues a function to be called during a browser's idle periods
- *
  * @callback RequestIdleCallback
  * @param {function(IdleDeadline)} callback
  * @param {{timeout: number}} options - an options object
@@ -106,7 +105,6 @@ if (typeof require === "function" && typeof module === "object") {
 
 /**
  * Configuration object for the `install` method.
- *
  * @typedef {object} Config
  * @property {number|Date} [now] a number (in milliseconds) or a Date object (default epoch)
  * @property {string[]} [toFake] names of the methods that should be faked.
@@ -120,7 +118,6 @@ if (typeof require === "function" && typeof module === "object") {
 /* eslint-disable jsdoc/require-property-description */
 /**
  * The internal structure to describe a scheduled fake timer
- *
  * @typedef {object} Timer
  * @property {Function} func
  * @property {*[]} args
@@ -134,7 +131,6 @@ if (typeof require === "function" && typeof module === "object") {
 
 /**
  * A Node timer
- *
  * @typedef {object} NodeImmediate
  * @property {function(): boolean} hasRef
  * @property {function(): NodeImmediate} ref
@@ -146,7 +142,6 @@ if (typeof require === "function" && typeof module === "object") {
 
 /**
  * Mocks available features in the specified global namespace.
- *
  * @param {*} _global Namespace to mock (e.g. `window`)
  * @returns {FakeTimers}
  */
@@ -276,7 +271,6 @@ function withGlobal(_global) {
      * Parse strings like "01:10:00" (meaning 1 hour, 10 minutes, 0 seconds) into
      * number of milliseconds. This is used to support human-readable strings passed
      * to clock.tick()
-     *
      * @param {string} str
      * @returns {number}
      */
@@ -312,7 +306,6 @@ function withGlobal(_global) {
 
     /**
      * Get the decimal part of the millisecond value as nanoseconds
-     *
      * @param {number} msFloat the number of milliseconds
      * @returns {number} an integer number of nanoseconds in the range [0,1e6)
      *
@@ -329,7 +322,6 @@ function withGlobal(_global) {
 
     /**
      * Used to grok the `now` parameter to createClock.
-     *
      * @param {Date|number} epoch the system time
      * @returns {number}
      */
@@ -483,7 +475,6 @@ function withGlobal(_global) {
         /**
          * A normal Class constructor cannot be called without `new`, but Date can, so we need
          * to wrap it in a Proxy in order to ensure this functionality of Date is kept intact
-         *
          * @type {ClockDate}
          */
         const ClockDateProxy = new Proxy(ClockDate, {
@@ -510,7 +501,6 @@ function withGlobal(_global) {
      * Most of the properties are the original native ones,
      * but we need to take control of those that have a
      * dependency on the current clock.
-     *
      * @returns {object} the partly fake Intl implementation
      */
     function createIntl() {
@@ -683,7 +673,6 @@ function withGlobal(_global) {
     /* eslint consistent-return: "off" */
     /**
      * Timer comparitor
-     *
      * @param {Timer} a
      * @param {Timer} b
      * @returns {number}
@@ -815,7 +804,6 @@ function withGlobal(_global) {
 
     /**
      * Gets clear handler name for a given timer type
-     *
      * @param {string} ttype
      */
     function getClearHandler(ttype) {
@@ -827,7 +815,6 @@ function withGlobal(_global) {
 
     /**
      * Gets schedule handler name for a given timer type
-     *
      * @param {string} ttype
      */
     function getScheduleHandler(ttype) {
@@ -1183,13 +1170,11 @@ function withGlobal(_global) {
 
         /**
          * A high resolution timestamp in milliseconds.
-         *
          * @typedef {number} DOMHighResTimeStamp
          */
 
         /**
          * performance.now()
-         *
          * @returns {DOMHighResTimeStamp}
          */
         function fakePerformanceNow() {
@@ -1848,7 +1833,8 @@ function withGlobal(_global) {
                     new FakePerformanceEntry(name, "mark", 0, 0);
                 clock.performance.measure = (name) =>
                     new FakePerformanceEntry(name, "measure", 0, 100);
-                // ensure `timeOrigin` returns a valid value
+                // `timeOrigin` should return the time of when the Window session started
+                // (or the Worker was installed)
                 clock.performance.timeOrigin = getEpoch(config.now);
             } else if ((config.toFake || []).includes("performance")) {
                 return handleMissingTimer("performance");

--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -1848,6 +1848,10 @@ function withGlobal(_global) {
                     new FakePerformanceEntry(name, "mark", 0, 0);
                 clock.performance.measure = (name) =>
                     new FakePerformanceEntry(name, "measure", 0, 100);
+                // ensure `timeOrigin` returns a valid value
+                clock.performance.timeOrigin = config.now
+                    ? getEpoch(config.now)
+                    : new Date().getTime();
             } else if ((config.toFake || []).includes("performance")) {
                 return handleMissingTimer("performance");
             }

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -3689,9 +3689,9 @@ describe("FakeTimers", function () {
                     return this.skip();
                 }
 
-                this.clock = FakeTimers.install();
+                this.clock = FakeTimers.install({ now: new Date(1234) });
                 assert.isNumber(performance.timeOrigin);
-                assert.isTrue(performance.timeOrigin > 0);
+                assert.equals(performance.timeOrigin, 1234);
             });
 
             it("should replace the getEntries, getEntriesByX methods with noops that return []", function () {
@@ -4798,7 +4798,6 @@ describe("FakeTimers", function () {
 
         /**
          * Returns elements that are present in both lists.
-         *
          * @function
          * @template E
          * @param {E[]} [list1]
@@ -4811,7 +4810,6 @@ describe("FakeTimers", function () {
 
         /**
          * Get property names and original values from timers module.
-         *
          * @function
          * @param {string[]} [toFake]
          * @returns {{propertyName: string, originalValue: any}[]}
@@ -5958,7 +5956,6 @@ describe("Node Timer: ref(), unref(),hasRef()", function () {
 describe("Intl API", function () {
     /**
      * Tester function to check if the globally hijacked Intl object is plugging into the faked Clock
-     *
      * @param {string} ianaTimeZone - IANA time zone name
      * @param {number} timestamp - UNIX timestamp
      * @returns {boolean}

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -3684,6 +3684,16 @@ describe("FakeTimers", function () {
                 testEntry(performance.measure("bar", "s", "t"));
             });
 
+            it("should create fake version of `timeOrigin` that returns the installed time", function () {
+                if (typeof Performance === "undefined") {
+                    return this.skip();
+                }
+
+                this.clock = FakeTimers.install();
+                assert.isNumber(performance.timeOrigin);
+                assert.isTrue(performance.timeOrigin > 0);
+            });
+
             it("should replace the getEntries, getEntriesByX methods with noops that return []", function () {
                 if (typeof Performance === "undefined") {
                     return this.skip();


### PR DESCRIPTION
Fixes #514

#### Purpose (TL;DR) - mandatory

Return valid value for `performance.timeOrigin` instead of `NOOP`. This fixes an issue in tests that depend on `performance.timeOrigin` having a valid value.

#### Background (Problem in detail)  - optional

See #514

#### Solution  - optional

Set `performance.timeOrigin` to a dummy value. I'm not sure if 0 is better than setting the value to `clock.now`. When testing `performance.timeOrigin` in Chrome Console I can see that the value is set to the timestamp when the window was opened:

```
> globalThis.performance.timeOrigin
1733227796841
```

There is further information in MDS docs on how the value is supposed to be set: https://developer.mozilla.org/en-US/docs/Web/API/Performance/timeOrigin#value