### PR TITLE
fix: Resilient to prototype pollution of Intl

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -206,7 +206,12 @@ function withGlobal(_global) {
     }
 
     const NativeDate = _global.Date;
-    const NativeIntl = _global.Intl;
+    const NativeIntl = isPresent.Intl
+        ? Object.defineProperties(
+              Object.create(null),
+              Object.getOwnPropertyDescriptors(_global.Intl),
+          )
+        : undefined;
     let uniqueTimerId = idCounterStart;
 
     if (NativeDate === undefined) {
@@ -1107,7 +1112,7 @@ function withGlobal(_global) {
     }
 
     if (isPresent.Intl) {
-        timers.Intl = _global.Intl;
+        timers.Intl = NativeIntl;
     }
 
     const originalSetTimeout = _global.setImmediate || _global.setTimeout;

--- a/test/issue-516-test.js
+++ b/test/issue-516-test.js
@@ -1,0 +1,20 @@
+"use strict";
+
+const { FakeTimers } = require("./helpers/setup-tests");
+
+describe("issue #516 - not resilient to changes on Intl", function () {
+    it("should successfully install the timer", function () {
+        const originalIntlProperties = Object.getOwnPropertyDescriptors(
+            global.Intl,
+        );
+        for (const key of Object.keys(originalIntlProperties)) {
+            delete global.Intl[key];
+        }
+        try {
+            const clock = FakeTimers.createClock();
+            clock.tick(16);
+        } finally {
+            Object.defineProperties(global.Intl, originalIntlProperties);
+        }
+    });
+});


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

This PR is supposed to fix #516. It should make fake-times a bit more resilient to prototype poisoning occurring directly on `Intl`. That said it does not handle deeper prototype breakings.

<!--
> give a concise (one or two short sentences) description of what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->

<!--
#### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->

<!--
#### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->
