### PR TITLE
fix: do not resurrect a timer cleared during the same tick

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -1515,7 +1515,13 @@ function withGlobal(_global) {
             if (clock.isNearInfiniteLimit) {
                 timer.error = new Error();
             }
-            clock.timerHeap.push(timer);
+            // Only reschedule a timer that is still registered. Pushing back one that has been
+            // cleared would leave the heap holding a timer `clock.timers` no longer has, and
+            // `firstTimerInRange` would keep handing it to `runTimersInRange`, which skips it
+            // because `hasTimer` reports it gone - a loop that never advances the clock.
+            if (hasTimer(clock, timer.id)) {
+                clock.timerHeap.push(timer);
+            }
         } else {
             deleteTimer(clock, timer.id);
             clock.timerHeap.remove(timer);
@@ -2227,7 +2233,12 @@ function withGlobal(_global) {
                     state.oldNow = clock.now;
                     try {
                         runJobs(clock);
-                        callTimer(clock, state.timer);
+                        // A job may have cleared this timer, e.g. a microtask calling
+                        // clearInterval() for the very timer that is up next. A cleared timer
+                        // must not fire, so re-check before calling it.
+                        if (hasTimer(clock, state.timer.id)) {
+                            callTimer(clock, state.timer);
+                        }
                     } catch (e) {
                         state.firstException = state.firstException || e;
                     }

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -3080,6 +3080,22 @@ describe("FakeTimers", function () {
             assert.isFalse(stub.called);
         });
 
+        it("does not fire a timeout cleared from a microtask mid-tick", function () {
+            const clock = this.clock;
+            const stub = sinon.stub();
+            const id = clock.setTimeout(stub, 100);
+
+            clock.setTimeout(function () {
+                clock.queueMicrotask(function () {
+                    clock.clearTimeout(id);
+                });
+            }, 50);
+
+            clock.tick(100);
+
+            assert.isFalse(stub.called);
+        });
+
         it("removes interval with undefined interval", function () {
             const stub = sinon.stub();
             const id = this.clock.setInterval(stub);
@@ -3271,6 +3287,25 @@ describe("FakeTimers", function () {
             this.clock.tick(50);
 
             assert.isFalse(stub.called);
+        });
+
+        it("does not fire or reschedule an interval cleared from a microtask mid-tick", function () {
+            const clock = this.clock;
+            const stub = sinon.stub();
+            const id = clock.setInterval(stub, 100);
+
+            // The job runs inside the same tick, after the interval has been picked as the next
+            // timer to fire but before its callback is invoked.
+            clock.setTimeout(function () {
+                clock.queueMicrotask(function () {
+                    clock.clearInterval(id);
+                });
+            }, 50);
+
+            clock.tick(100);
+
+            assert.isFalse(stub.called);
+            assert.equals(clock.countTimers(), 0);
         });
 
         it("removes interval with undefined interval", function () {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

A timer cleared from a microtask during `clock.tick()` is still fired, and if it is an interval it is
pushed back onto `clock.timerHeap` after `clearTimer` already deleted it from `clock.timers`. The heap
and the id map then disagree permanently, and the next `tick()`/`runToLast()` spins forever without
advancing the clock.

#### Background (Problem in detail)

`runTimersInRange` picks the next timer, checks `hasTimer` for it, and then calls `runJobs(clock)`
before invoking it:

```js
while (state.timer && state.tickFrom <= state.tickTo) {
    if (hasTimer(clock, state.timer.id)) {
        state.tickFrom = state.timer.callAt;
        clock.now = state.timer.callAt;
        state.oldNow = clock.now;
        try {
            runJobs(clock);
            callTimer(clock, state.timer);
```

A job can clear the very timer that is about to fire. `callTimer` then runs on a timer that
`clearTimer` has already deleted from `clock.timers` and removed from the heap, and for an interval it
advances `callAt` and pushes it back unconditionally:

```js
if (typeof timer.interval === "number") {
    clock.timerHeap.remove(timer);   // bails: heapIndex is already undefined
    timer.callAt += timer.interval;
    ...
    clock.timerHeap.push(timer);     // re-adds a timer clock.timers no longer has
}
```

From then on `firstTimerInRange` keeps returning that timer while `hasTimer` reports it gone, so
`runTimersInRange` loops without calling anything and without advancing `clock.now`. `doTick` has no
iteration guard — the `loopLimit` check lives only in `clock.runAll` — so the loop never terminates,
and because it is synchronous no test timeout can interrupt it.

Minimal reproduction:

```js
const clock = FakeTimers.install({ now: 0 });

const interval = setInterval(() => {}, 100);

// runs inside runJobs(), after hasTimer(interval) passed but before callTimer(interval)
setTimeout(() => queueMicrotask(() => clearInterval(interval)), 50);

clock.tick(100);

clock.timers.size;              // 0
clock.timerHeap.timers.length;  // 1  <- phantom
clock.countTimers();            // 1  <- public API reports a timer that was cleared
// clock.tick(1) or clock.runToLast() from here never returns
```

Found in an enterprise React Native app's Jest suite: MSW delivers a mocked WebSocket message on a microtask, the app's socket watchdog clears its own `setInterval` in response, and a single`jest.runOnlyPendingTimers()` inside that window pinned one worker at 100% CPU indefinitely. Because the loop is synchronous, Jest's per-test timeout could never fire — the run presented as a suite that passed every test and then never printed a summary.

#### Solution

Two changes in `src/fake-timers-src.js`:

- `runTimersInRange` re-checks that the timer is still registered after `runJobs`, so a cleared timer
  does not fire. This matches real timers: clearing in a microtask before the callback is due prevents
  it from running.
- `callTimer` only pushes an interval back onto the heap while it is still registered, so no caller
  can leave the heap and the id map out of sync. `clock.next()` and `clock.runAll()` reach `callTimer`
  by different paths, and this keeps the invariant in one place rather than making every heap reader
  defensive.

Two regression tests, one per half of the fix — a cleared interval must neither fire nor stay
scheduled, a cleared timeout must not fire. Both fail on `main` and pass with the change.

The tests assert `countTimers() === 0` rather than proving the non-termination directly: a test that
actually triggers the spin would hang the suite instead of failing it, since `--timeout 200` cannot
interrupt a synchronous loop.
