### PR TITLE
feat: fake AbortSignal.timeout when faking setTimeout (#521)

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -442,6 +442,7 @@ if (typeof require === "function" && typeof module === "object") {
  * @property {boolean} [shouldClearNativeTimers] - inherited from config
  * @property {{methodName:string, original:unknown}[] | undefined} timersModuleMethods - saved Node timers module methods
  * @property {{methodName:string, original:unknown}[] | undefined} timersPromisesModuleMethods - saved Node timers/promises methods
+ * @property {{methodName:string, original:unknown}[] | undefined} abortSignalMethods - saved AbortSignal methods
  * @property {Map<VoidVarArgsFunc, AbortSignal>} abortListenerMap - active abort listeners
  * @property {SetTickMode} setTickMode - switches the auto-tick mode
  * @property {Map<number, Timer>} [timers] - internal timer storage
@@ -2646,6 +2647,17 @@ function withGlobal(_global) {
                                 entry.original;
                         }
                     }
+                    if (clock.abortSignalMethods !== undefined) {
+                        for (
+                            let j = 0;
+                            j < clock.abortSignalMethods.length;
+                            j++
+                        ) {
+                            const entry = clock.abortSignalMethods[j];
+                            _global.AbortSignal[entry.methodName] =
+                                entry.original;
+                        }
+                    }
                 }
 
                 // Prevent multiple executions which will completely remove these props
@@ -2821,6 +2833,12 @@ function withGlobal(_global) {
         }
         if (_global === globalObject && timersPromisesModule) {
             clock.timersPromisesModuleMethods = [];
+        }
+        if (
+            _global.AbortSignal &&
+            typeof _global.AbortSignal.timeout === "function"
+        ) {
+            clock.abortSignalMethods = [];
         }
         for (i = 0, l = clock.methods.length; i < l; i++) {
             const nameOfMethodToReplace = clock.methods[i];
@@ -3095,6 +3113,45 @@ function withGlobal(_global) {
                         },
                     });
                 }
+            }
+            if (
+                clock.abortSignalMethods !== undefined &&
+                nameOfMethodToReplace === "setTimeout"
+            ) {
+                const original = _global.AbortSignal.timeout;
+                clock.abortSignalMethods.push({
+                    methodName: "timeout",
+                    original: original,
+                });
+
+                _global.AbortSignal.timeout = (delay) => {
+                    if (
+                        typeof delay !== "number" ||
+                        !Number.isInteger(delay) ||
+                        delay < 0 ||
+                        delay > 4294967295
+                    ) {
+                        return original.call(_global.AbortSignal, delay);
+                    }
+
+                    const controller = new _global.AbortController();
+                    clock.setTimeout(() => {
+                        let reason;
+                        if (typeof _global.DOMException !== "undefined") {
+                            reason = new _global.DOMException(
+                                "The operation was aborted due to timeout",
+                                "TimeoutError",
+                            );
+                        } else {
+                            reason = new Error(
+                                "The operation was aborted due to timeout",
+                            );
+                            reason.name = "TimeoutError";
+                        }
+                        controller.abort(reason);
+                    }, delay);
+                    return controller.signal;
+                };
             }
         }
 

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -6028,6 +6028,91 @@ describe("FakeTimers", function () {
             });
         });
     });
+
+    describe("AbortSignal.timeout", function () {
+        let clock;
+
+        before(function () {
+            if (
+                typeof AbortSignal === "undefined" ||
+                typeof AbortSignal.timeout !== "function"
+            ) {
+                this.skip();
+            }
+        });
+
+        afterEach(function () {
+            if (clock) {
+                clock.uninstall();
+                clock = undefined;
+            }
+        });
+
+        it("should fake AbortSignal.timeout on install", function () {
+            const original = AbortSignal.timeout;
+            clock = FakeTimers.install();
+            refute.equals(AbortSignal.timeout, original);
+        });
+
+        it("should restore AbortSignal.timeout on uninstall", function () {
+            const original = AbortSignal.timeout;
+            clock = FakeTimers.install();
+            clock.uninstall();
+            clock = undefined;
+            assert.equals(AbortSignal.timeout, original);
+        });
+
+        it("should abort after specified time with TimeoutError", function () {
+            clock = FakeTimers.install();
+            const signal = AbortSignal.timeout(100);
+
+            assert.isFalse(signal.aborted);
+            assert.isUndefined(signal.reason);
+
+            clock.tick(50);
+            assert.isFalse(signal.aborted);
+
+            clock.tick(50);
+            assert.isTrue(signal.aborted);
+            assert.equals(signal.reason.name, "TimeoutError");
+        });
+
+        it("should trigger abort event listener after specified time", function () {
+            clock = FakeTimers.install();
+            const signal = AbortSignal.timeout(100);
+            const onAbort = sinon.spy();
+            signal.addEventListener("abort", onAbort);
+
+            clock.tick(99);
+            assert.isFalse(onAbort.called);
+
+            clock.tick(1);
+            assert.isTrue(onAbort.calledOnce);
+        });
+
+        it("should delegate validation of invalid delay to native implementation", function () {
+            clock = FakeTimers.install();
+            assert.exception(
+                function () {
+                    AbortSignal.timeout(-1);
+                },
+                { name: "RangeError" },
+            );
+
+            assert.exception(
+                function () {
+                    AbortSignal.timeout(NaN);
+                },
+                { name: "RangeError" },
+            );
+        });
+
+        it("should not fake AbortSignal.timeout when setTimeout is not in toFake", function () {
+            const original = AbortSignal.timeout;
+            clock = FakeTimers.install({ toFake: ["Date"] });
+            assert.equals(AbortSignal.timeout, original);
+        });
+    });
 });
 
 describe("loop limit stack trace", function () {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Fix issue #521 by faking `AbortSignal.timeout()` when `setTimeout` is faked, allowing fake timers to control timeout-based abort signals.

#### Background (Problem in detail)

In Node.js 17.3+ and modern browsers, `AbortSignal.timeout(delay)` schedules a timer that aborts the signal after `delay` milliseconds with a `TimeoutError`. When fake timers are installed, calls to `AbortSignal.timeout()` would previously remain bound to native timers, preventing `clock.tick()` / `clock.tickAsync()` from controlling the signal's abort timing.

#### Solution

- When `setTimeout` is replaced and `AbortSignal.timeout` is present in the global scope, replace `AbortSignal.timeout(delay)` with an implementation backed by `clock.setTimeout()`.
- Aborts with a `DOMException('The operation was aborted due to timeout', 'TimeoutError')` (falling back to a named `Error` if `DOMException` is unavailable).
- Invalid arguments (non-integer, negative, or out-of-range delays) delegate to the native `AbortSignal.timeout` to preserve runtime error types and messages.
- Restores original `AbortSignal.timeout` upon `clock.uninstall()`.
- Added unit tests covering install, uninstall, timing with `clock.tick`, abort event emission, and argument validation.